### PR TITLE
Improve error reporting heuristics and benches

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -14,8 +14,7 @@ fn bench_lexer(c: &mut Criterion) {
     c.bench_function("lexer", |b| {
         b.iter(|| {
             let mut lexer = Lexer::new(input);
-            let tokens = lexer.next_token();
-            black_box(tokens);
+            black_box(lexer.next_token());
         })
     });
 }
@@ -30,8 +29,7 @@ fn bench_parser(c: &mut Criterion) {
     c.bench_function("parser", |b| {
         b.iter(|| {
             let mut parser = Parser::new(input);
-            let (bid, _) = parser.parse_program();
-            black_box(bid);
+            black_box(parser.parse_program());
         })
     });
 }

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -14,7 +14,9 @@ fn bench_lexer(c: &mut Criterion) {
     c.bench_function("lexer", |b| {
         b.iter(|| {
             let mut lexer = Lexer::new(input);
-            black_box(lexer.next_token());
+            while let Some(token) = lexer.next_token() {
+                black_box(token);
+            }
         })
     });
 }

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -2,7 +2,7 @@ use std::hint::black_box;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use naijascript::syntax::parser::Parser;
-use naijascript::syntax::scanner::Lexer;
+use naijascript::syntax::scanner::{Lexer, Token};
 
 fn bench_lexer(c: &mut Criterion) {
     let input = black_box(
@@ -14,7 +14,11 @@ fn bench_lexer(c: &mut Criterion) {
     c.bench_function("lexer", |b| {
         b.iter(|| {
             let mut lexer = Lexer::new(input);
-            while let Some(token) = lexer.next_token() {
+            loop {
+                let token = lexer.next_token();
+                if token == Token::EOF {
+                    break;
+                }
                 black_box(token);
             }
         })

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -30,7 +30,8 @@ fn bench_parser(c: &mut Criterion) {
     c.bench_function("parser", |b| {
         b.iter(|| {
             let mut parser = Parser::new(input);
-            let _ = parser.parse_program();
+            let (bid, _) = parser.parse_program();
+            black_box(bid);
         })
     });
 }

--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -137,26 +137,24 @@ pub enum SyntaxError {
 impl AsStr for SyntaxError {
     fn as_str(&self) -> &'static str {
         match self {
-            SyntaxError::ExpectedStatement => "I dey expect statement for here",
-            SyntaxError::ExpectedIdentifierAfterMake => "I dey expect variable name after `make`",
-            SyntaxError::ExpectedGetAfterIdentifier => "I dey expect `get` after variable name",
-            SyntaxError::ExpectedLParenAfterShout => "I dey expect `(` after `shout`",
-            SyntaxError::ExpectedRParenAfterShout => "I dey expect `)` after shout expression",
-            SyntaxError::ExpectedLParenAfterIf => "I dey expect `(` after `if to say`",
-            SyntaxError::ExpectedRParenAfterIf => "I dey expect `)` after if condition",
-            SyntaxError::ExpectedStartForThenBlock => "I dey expect `start` for then-block",
-            SyntaxError::UnterminatedThenBlock => "I no see `end` for then-block",
-            SyntaxError::ExpectedStartForElseBlock => "I dey expect `start` for else-block",
-            SyntaxError::UnterminatedElseBlock => "I no see `end` for else-block",
-            SyntaxError::ExpectedLParenAfterJasi => "I dey expect `(` after `jasi`",
-            SyntaxError::ExpectedRParenAfterJasi => "I dey expect `)` after loop condition",
-            SyntaxError::ExpectedStartForLoopBody => "I dey expect `start` for loop body",
-            SyntaxError::UnterminatedLoopBody => "I no see `end` for loop body",
-            SyntaxError::ExpectedComparisonOperator => {
-                "I dey expect comparison operator (`na`/`pass`/`small pass`)"
-            }
-            SyntaxError::ExpectedNumberOrVariableOrLParen => "I dey expect number, variable or `(`",
-            SyntaxError::TrailingTokensAfterProgramEnd => "I see extra tokens after program end",
+            SyntaxError::ExpectedStatement => "Statement syntax no correct",
+            SyntaxError::ExpectedIdentifierAfterMake => "Assignment syntax no complete",
+            SyntaxError::ExpectedGetAfterIdentifier => "Assignment syntax no correct",
+            SyntaxError::ExpectedLParenAfterShout => "Shout syntax no complete",
+            SyntaxError::ExpectedRParenAfterShout => "Shout syntax no complete",
+            SyntaxError::ExpectedLParenAfterIf => "If statement syntax no complete",
+            SyntaxError::ExpectedRParenAfterIf => "If statement syntax no complete",
+            SyntaxError::ExpectedStartForThenBlock => "If block syntax no complete",
+            SyntaxError::UnterminatedThenBlock => "If block syntax no complete",
+            SyntaxError::ExpectedStartForElseBlock => "Else block syntax no complete",
+            SyntaxError::UnterminatedElseBlock => "Else block syntax no complete",
+            SyntaxError::ExpectedLParenAfterJasi => "Loop syntax no complete",
+            SyntaxError::ExpectedRParenAfterJasi => "Loop syntax no complete",
+            SyntaxError::ExpectedStartForLoopBody => "Loop block syntax no complete",
+            SyntaxError::UnterminatedLoopBody => "Loop block syntax no complete",
+            SyntaxError::ExpectedComparisonOperator => "Condition syntax no complete",
+            SyntaxError::ExpectedNumberOrVariableOrLParen => "Expression syntax no complete",
+            SyntaxError::TrailingTokensAfterProgramEnd => "Program syntax no complete",
         }
     }
 }
@@ -285,13 +283,13 @@ impl<'src> Parser<'src> {
                     let mut message = "I dey expect statement for here";
                     // Suggest a keyword if close to a known one
                     if Self::suggest_keyword(var, "make").is_some() {
-                        message = "I dey expect statement for here. You fit mean `make`?";
+                        message = "You fit mean `make`?";
                     } else if Self::suggest_keyword(var, "shout").is_some() {
-                        message = "I dey expect statement for here. You fit mean `shout`?";
+                        message = "You fit mean `shout`?";
                     } else if Self::suggest_keyword(var, "jasi").is_some() {
-                        message = "I dey expect statement for here. You fit mean `jasi`?";
+                        message = "You fit mean `jasi`?";
                     } else if Self::suggest_keyword(var, "if").is_some() {
-                        message = "I dey expect statement for here. You fit mean `if to say`?";
+                        message = "You fit mean `if to say`?";
                     }
                     self.errors.emit(
                         start..self.lexer.pos,
@@ -311,7 +309,7 @@ impl<'src> Parser<'src> {
                     SyntaxError::ExpectedStatement.as_str(),
                     vec![Label {
                         span: start..self.lexer.pos,
-                        message: "I dey expect statement for here",
+                        message: "I dey expect `make`, `shout`, `if to say`, `jasi`, or variable reassignment for here",
                     }],
                 );
                 None
@@ -337,7 +335,7 @@ impl<'src> Parser<'src> {
                 SyntaxError::ExpectedIdentifierAfterMake.as_str(),
                 vec![Label {
                     span: self.lexer.pos..self.lexer.pos + 1,
-                    message: "I dey expect variable name for here",
+                    message: "Put variable name after `make` for here",
                 }],
             );
             return None;
@@ -351,7 +349,7 @@ impl<'src> Parser<'src> {
                 SyntaxError::ExpectedGetAfterIdentifier.as_str(),
                 vec![Label {
                     span: self.lexer.pos..self.lexer.pos + 1,
-                    message: "I dey expect `get` for here",
+                    message: "Put `get` after variable name for here",
                 }],
             );
             return None;
@@ -377,7 +375,7 @@ impl<'src> Parser<'src> {
                 SyntaxError::ExpectedLParenAfterShout.as_str(),
                 vec![Label {
                     span: self.lexer.pos..self.lexer.pos + 1,
-                    message: "I dey expect `(` for here",
+                    message: "Put `(` after `shout` for here",
                 }],
             );
             return None;
@@ -392,7 +390,7 @@ impl<'src> Parser<'src> {
                 SyntaxError::ExpectedRParenAfterShout.as_str(),
                 vec![Label {
                     span: self.lexer.pos..self.lexer.pos + 1,
-                    message: "I dey expect `)` for here",
+                    message: "Close shout with `)` for here",
                 }],
             );
             return None;
@@ -417,7 +415,7 @@ impl<'src> Parser<'src> {
                 SyntaxError::ExpectedLParenAfterIf.as_str(),
                 vec![Label {
                     span: self.lexer.pos..self.lexer.pos + 1,
-                    message: "I dey expect `(` for here",
+                    message: "Put `(` after `if to say` for here",
                 }],
             );
             return None;
@@ -432,7 +430,7 @@ impl<'src> Parser<'src> {
                 SyntaxError::ExpectedRParenAfterIf.as_str(),
                 vec![Label {
                     span: self.lexer.pos..self.lexer.pos + 1,
-                    message: "I dey expect `)` for here",
+                    message: "Close condition with `)` for here",
                 }],
             );
             return None;
@@ -448,7 +446,7 @@ impl<'src> Parser<'src> {
                 SyntaxError::ExpectedStartForThenBlock.as_str(),
                 vec![Label {
                     span: self.lexer.pos..self.lexer.pos + 1,
-                    message: "I dey expect `start` for here",
+                    message: "Begin block with `start` for here",
                 }],
             );
             return None;
@@ -465,7 +463,7 @@ impl<'src> Parser<'src> {
                 SyntaxError::UnterminatedThenBlock.as_str(),
                 vec![Label {
                     span: start..start + 5, // highlight 'start'
-                    message: "Block start here, but I no see `end`",
+                    message: "Dis block start here, but I no see `end`",
                 }],
             );
         }
@@ -481,7 +479,7 @@ impl<'src> Parser<'src> {
                     SyntaxError::ExpectedStartForElseBlock.as_str(),
                     vec![Label {
                         span: self.lexer.pos..self.lexer.pos + 1,
-                        message: "I dey expect `start` for here",
+                        message: "Begin else block with `start` for here",
                     }],
                 );
                 return None;
@@ -498,7 +496,7 @@ impl<'src> Parser<'src> {
                     SyntaxError::UnterminatedElseBlock.as_str(),
                     vec![Label {
                         span: start..start + 5,
-                        message: "Block start here, but I no see `end`",
+                        message: "Dis else block start here, but I no see `end`",
                     }],
                 );
             }
@@ -525,7 +523,7 @@ impl<'src> Parser<'src> {
                 SyntaxError::ExpectedLParenAfterJasi.as_str(),
                 vec![Label {
                     span: self.lexer.pos..self.lexer.pos + 1,
-                    message: "I dey expect `(` for here",
+                    message: "Put `(` after `jasi` for here",
                 }],
             );
             return None;
@@ -540,7 +538,7 @@ impl<'src> Parser<'src> {
                 SyntaxError::ExpectedRParenAfterJasi.as_str(),
                 vec![Label {
                     span: self.lexer.pos..self.lexer.pos + 1,
-                    message: "I dey expect `)` for here",
+                    message: "Close loop condition with `)` for here",
                 }],
             );
             return None;
@@ -554,7 +552,7 @@ impl<'src> Parser<'src> {
                 SyntaxError::ExpectedStartForLoopBody.as_str(),
                 vec![Label {
                     span: self.lexer.pos..self.lexer.pos + 1,
-                    message: "I dey expect `start` for here",
+                    message: "Begin loop body with `start` for here",
                 }],
             );
             return None;
@@ -571,7 +569,7 @@ impl<'src> Parser<'src> {
                 SyntaxError::UnterminatedLoopBody.as_str(),
                 vec![Label {
                     span: start..start + 5,
-                    message: "Block start here, but I no see `end`",
+                    message: "Dis loop body start here, but I no see `end`",
                 }],
             );
         }
@@ -599,7 +597,7 @@ impl<'src> Parser<'src> {
                     SyntaxError::ExpectedComparisonOperator.as_str(),
                     vec![Label {
                         span: self.lexer.pos..self.lexer.pos + 1,
-                        message: "I dey expect comparison operator for here",
+                        message: "Use `na`, `pass`, or `small pass` to compare for here",
                     }],
                 );
                 CmpOp::Eq // fallback to something reasonable
@@ -647,7 +645,7 @@ impl<'src> Parser<'src> {
                         SyntaxError::ExpectedRParenAfterShout.as_str(),
                         vec![Label {
                             span: self.lexer.pos..self.lexer.pos + 1,
-                            message: "I dey expect `)` for here",
+                            message: "Close expression with `)` for here",
                         }],
                     );
                 } else {
@@ -663,7 +661,7 @@ impl<'src> Parser<'src> {
                     SyntaxError::ExpectedNumberOrVariableOrLParen.as_str(),
                     vec![Label {
                         span: self.lexer.pos..self.lexer.pos + 1,
-                        message: "I dey expect number, variable or `(` for here",
+                        message: "Use number, variable name, or `(` for expression for here",
                     }],
                 );
                 let s = start..self.lexer.pos;

--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -280,7 +280,7 @@ impl<'src> Parser<'src> {
                     Some(sid)
                 } else {
                     // Not a reassignment, error and do not consume
-                    let mut message = "I dey expect statement for here";
+                    let mut message = "Statement syntax no complete";
                     // Suggest a keyword if close to a known one
                     if Self::suggest_keyword(var, "make").is_some() {
                         message = "You fit mean `make`?";

--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -280,7 +280,7 @@ impl<'src> Parser<'src> {
                     Some(sid)
                 } else {
                     // Not a reassignment, error and do not consume
-                    let mut message = "Statement syntax no complete";
+                    let mut message = "I dey expect statement for here";
                     // Suggest a keyword if close to a known one
                     if Self::suggest_keyword(var, "make").is_some() {
                         message = "You fit mean `make`?";


### PR DESCRIPTION
## Pull Request Overview

This PR refines the error reporting in the parser by updating the error messages to more concise phrasing and introduces a heuristic to suggest keywords. It also improves the performance benchmarks by iterating through all tokens in the lexer rather than processing a single token.