### PR TITLE
Fix windows installer bug

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,10 +78,7 @@ jobs:
             *) echo "Unknown target"; exit 1 ;;
           esac
 
-          EXT=""
-          if [ "$PLATFORM" = "windows" ]; then EXT=".exe"; fi
-
-          BIN_NAME="${{ matrix.bin_target }}-$PLATFORM-$ARCH$EXT"
+          BIN_NAME="${{ matrix.bin_target }}-$PLATFORM-$ARCH"
           echo "bin_name=$BIN_NAME" >> $GITHUB_OUTPUT
       - name: Rename binary
         shell: bash

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -76,5 +76,5 @@ Write-Host "If you wan install NaijaScript interpreter, run: naijaup install lat
 Write-Host "Oya, you fit enjoy NaijaScript now!"
 
 # --- Cleanup ---
-Set-Location $HOME
+Set-Location $env:USERPROFILE
 Remove-Item -Recurse -Force $tmp


### PR DESCRIPTION
Adjust the binary naming in the release workflow for Windows and update the cleanup path to utilize the USERPROFILE environment variable instead of HOME.