### PR TITLE
Add support for boolean literals

### DIFF
--- a/docs/LRM.md
+++ b/docs/LRM.md
@@ -58,7 +58,7 @@ Whitespace (spaces, tabs, newlines) dey used to separate tokens and make code re
 
 ## 3. Grammar and Syntax
 
-NaijaScript syntax dey defined with a formal grammar using Backus-Naur Form (BNF). You fit check the full grammar for this link: [grammar](https://raw.githubusercontent.com/xosnrdev/naijascript/master/docs/grammar.bnf).
+NaijaScript syntax dey defined with a formal grammar using Backus-Naur Form (BNF). You fit check the full grammar for this [link](https://raw.githubusercontent.com/xosnrdev/naijascript/master/docs/grammar.bnf).
 
 ## 4. Static Semantics
 

--- a/docs/LRM.md
+++ b/docs/LRM.md
@@ -39,6 +39,9 @@ Literals na the fixed values wey you dey write directly for your code.
   - Example: `10`, `3.142`, `0.5`
 - **Strings**: A sequence of characters inside double quotes.
   - Example: `"Hello, World!"`, `"Naija no dey carry last"`
+- **Booleans**: Truth values wey be `true` and `false`.
+  - `true` - mean say e correct or e happen.
+  - `false` - mean say e no correct or e no happen.
 
 ### 2.4. Operators
 
@@ -67,6 +70,7 @@ NaijaScript get two main data types:
 
 - **Number**: Represents numeric values (e.g., `10`, `99.9`). All numbers na floating-point numbers.
 - **String**: Represents text (e.g., `"Naija"`).
+- **Boolean**: Represents truth values wey fit be `true` or `false`.
 
 Type inference dey automatic. You no need to declare the type of a variable.
 

--- a/docs/grammar.bnf
+++ b/docs/grammar.bnf
@@ -19,7 +19,9 @@
 
 <term> ::= <factor> | <term> "times" <factor> | <term> "divide" <factor> | <term> "remain" <factor>
 
-<factor> ::= <number> | <string> | <variable> | "(" <expression> ")"
+<factor> ::= <number> | <string> | <boolean> | <variable> | "(" <expression> ")"
+
+<boolean> ::= "true" | "false"
 
 <string> ::= "\"" { <string_char> } "\""
 <string_char> ::= any character except "\"" or "\\" | "\\" <escape_sequence>

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -224,6 +224,15 @@ impl<'src> Interpreter<'src> {
                 };
                 Ok(result)
             }
+            (Value::Bool(l), Value::Bool(r)) => {
+                let result = match c.op {
+                    CmpOp::Eq => l == r,
+                    // Boolean comparison follows Rust's standard where false equals 0 and true equals 1, so false comes before true in ordering
+                    CmpOp::Gt => l > r,
+                    CmpOp::Lt => l < r,
+                };
+                Ok(result)
+            }
             _ => unreachable!("Semantic analysis should guarantee only valid comparisons"),
         }
     }
@@ -235,6 +244,7 @@ impl<'src> Interpreter<'src> {
                 .map(Value::Number)
                 .map_err(|_| RuntimeError { kind: RuntimeErrorKind::InvalidNumber, span }),
             Expr::String(s, _) => Ok(Value::Str(s.clone())),
+            Expr::Bool(b, _) => Ok(Value::Bool(*b)),
             Expr::Var(v, _) => {
                 let val = self
                     .env

--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -91,6 +91,7 @@ pub enum Stmt<'src> {
 pub enum Expr<'src> {
     Number(&'src str, Span),                                    // 42, 3.14, etc.
     String(Cow<'src, str>, Span),                               // "hello", etc.
+    Bool(bool, Span),                                           // "true", "false"
     Var(&'src str, Span),                                       // variable references
     Binary { op: BinOp, lhs: ExprId, rhs: ExprId, span: Span }, // arithmetic operations
 }
@@ -655,6 +656,13 @@ impl<'src, I: Iterator<Item = SpannedToken<'src>>> Parser<'src, I> {
             Token::String(sval) => {
                 let s = self.cur.span.clone();
                 let id = self.expr_arena.alloc(Expr::String(sval.clone(), s));
+                self.bump();
+                id
+            }
+            Token::True | Token::False => {
+                let s = self.cur.span.clone();
+                let value = matches!(&self.cur.token, Token::True);
+                let id = self.expr_arena.alloc(Expr::Bool(value, s));
                 self.bump();
                 id
             }

--- a/src/syntax/scanner.rs
+++ b/src/syntax/scanner.rs
@@ -58,6 +58,10 @@ pub enum Token<'input> {
     IfToSay, // "if to say" - if statement
     IfNotSo, // "if not so" - else statement
 
+    // Boolean literals
+    True,  // "true" - true
+    False, // "false" - false
+
     // Punctuation
     LParen, // "("
     RParen, // ")"
@@ -460,6 +464,8 @@ impl<'input> Lexer<'input> {
             "end" => Token::End,
             "na" => Token::Na,
             "pass" => Token::Pass,
+            "true" => Token::True,
+            "false" => Token::False,
             // If not a keyword, it's an identifier
             other => {
                 // Let's make sure the identifier is valid:

--- a/src/syntax/scanner.rs
+++ b/src/syntax/scanner.rs
@@ -59,8 +59,8 @@ pub enum Token<'input> {
     IfNotSo, // "if not so" - else statement
 
     // Boolean literals
-    True,  // "true" - true
-    False, // "false" - false
+    True,  // "true" - truthy
+    False, // "false" - falsy
 
     // Punctuation
     LParen, // "("

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -124,3 +124,15 @@ fn test_parse_trailing_tokens() {
     let src = "make x get 5 123";
     assert_parse!(src, SyntaxError::TrailingTokensAfterProgramEnd);
 }
+
+#[test]
+fn test_parse_boolean_literals() {
+    let src = "make x get true make y get false";
+    assert_parse!(src);
+}
+
+#[test]
+fn test_parse_boolean_comparison() {
+    let src = "if to say (true na false) start end";
+    assert_parse!(src);
+}

--- a/tests/resolver.rs
+++ b/tests/resolver.rs
@@ -73,3 +73,18 @@ fn test_string_number_comparison_in_loop() {
 fn test_string_modulus() {
     assert_resolve!(r#"make x get "foo" remain "bar""#, SemanticError::InvalidStringOperation);
 }
+
+#[test]
+fn test_boolean_number_comparison() {
+    assert_resolve!("if to say (true na 1) start end", SemanticError::TypeMismatch);
+}
+
+#[test]
+fn test_boolean_string_comparison() {
+    assert_resolve!(r#"if to say (true na "test") start end"#, SemanticError::TypeMismatch);
+}
+
+#[test]
+fn test_boolean_arithmetic_operations() {
+    assert_resolve!("make x get true add false", SemanticError::TypeMismatch);
+}

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -153,3 +153,27 @@ fn empty_string_concatenation() {
 fn modulus_by_zero() {
     assert_runtime!("shout(5 remain 0)", error: RuntimeErrorKind::DivisionByZero);
 }
+
+#[test]
+fn boolean_literals() {
+    assert_runtime!("shout(true)", output: vec![Value::Bool(true)]);
+    assert_runtime!("shout(false)", output: vec![Value::Bool(false)]);
+}
+
+#[test]
+fn boolean_assignment() {
+    assert_runtime!("make x get true shout(x)", output: vec![Value::Bool(true)]);
+    assert_runtime!("make y get false shout(y)", output: vec![Value::Bool(false)]);
+}
+
+#[test]
+fn boolean_comparison() {
+    assert_runtime!("if to say (true na true) start shout(1) end", output: vec![Value::Number(1.0)]);
+    assert_runtime!("if to say (true na false) start shout(1) end if not so start shout(2) end", output: vec![Value::Number(2.0)]);
+}
+
+#[test]
+fn boolean_ordering() {
+    assert_runtime!("if to say (false small pass true) start shout(1) end", output: vec![Value::Number(1.0)]);
+    assert_runtime!("if to say (true pass false) start shout(1) end", output: vec![Value::Number(1.0)]);
+}

--- a/tests/scanner.rs
+++ b/tests/scanner.rs
@@ -18,7 +18,7 @@ macro_rules! assert_tokens {
 
 #[test]
 fn test_scan_keywords() {
-    let src = "make get add minus times divide remain shout jasi start end na pass small pass if to say if not so";
+    let src = "make get add minus times divide remain shout jasi start end na pass small pass if to say if not so true false";
     assert_tokens!(
         Lexer::new(src),
         Token::Make,
@@ -37,6 +37,8 @@ fn test_scan_keywords() {
         Token::SmallPass,
         Token::IfToSay,
         Token::IfNotSo,
+        Token::True,
+        Token::False,
         Token::EOF
     );
 }


### PR DESCRIPTION
## Pull Request Overview

This PR adds support for boolean literals in NaijaScript by extending the scanner, parser, runtime, resolver, tests, and documentation to handle the new "true" and "false" keywords.  
- Introduces Token variants and parsing logic for boolean literals.  
- Implements runtime evaluation and semantic analysis for booleans.  
- Updates tests and docs to cover boolean values.