### PR TITLE
Standardize modulus keyword to `mod`

### DIFF
--- a/docs/LRM.md
+++ b/docs/LRM.md
@@ -28,7 +28,7 @@ Keywords na special words wey get meaning for NaijaScript. You no fit use them a
 - `jasi`: Loop construct.
 - `start`: Beginning of a code block.
 - `end`: End of a code block.
-- `add`, `minus`, `times`, `divide`, `remain`: Arithmetic operators.
+- `add`, `minus`, `times`, `divide`, `mod`: Arithmetic operators.
 - `na`, `pass`, `small pass`: Comparison operators.
 
 ### 2.3. Literals
@@ -45,7 +45,7 @@ Literals na the fixed values wey you dey write directly for your code.
 
 ### 2.4. Operators
 
-- **Arithmetic**: `add` (+), `minus` (-), `times` (\*), `divide` (/), `remain` (%)
+- **Arithmetic**: `add` (+), `minus` (-), `times` (\*), `divide` (/), `mod` (%)
 - **Comparison**: `na` (==), `pass` (>), `small pass` (<)
 
 ### 2.5. Punctuation
@@ -96,7 +96,7 @@ This section dey explain wetin each part of the language dey do when e dey run.
 
 ### 5.2. Expressions
 
-- **Arithmetic**: Expressions with `add`, `minus`, `times`, `divide`, and `remain` go perform the calculation and return a `Number`. If you try to divide by zero or use remain with zero, e go cause a runtime error.
+- **Arithmetic**: Expressions with `add`, `minus`, `times`, `divide`, and `mod` go perform the calculation and return a `Number`. If you try to divide by zero or use mod with zero, e go cause a runtime error.
 - **String Concatenation**: You fit use the `add` operator to join two strings together.
 - **Comparison**: Expressions with `na`, `pass`, and `small pass` go compare two values and return a boolean result (true or false) for use in conditions.
 

--- a/docs/grammar.bnf
+++ b/docs/grammar.bnf
@@ -17,7 +17,7 @@
 
 <expression> ::= <term> | <expression> "add" <term> | <expression> "minus" <term>
 
-<term> ::= <factor> | <term> "times" <factor> | <term> "divide" <factor> | <term> "remain" <factor>
+<term> ::= <factor> | <term> "times" <factor> | <term> "divide" <factor> | <term> "mod" <factor>
 
 <factor> ::= <number> | <string> | <boolean> | <variable> | "(" <expression> ")"
 

--- a/examples/fizzbuzz.ns
+++ b/examples/fizzbuzz.ns
@@ -2,9 +2,9 @@ make i get 1
 
 jasi (i small pass 101)
 start
-    if to say (i remain 3 na 0)
+    if to say (i mod 3 na 0)
     start
-        if to say (i remain 5 na 0)
+        if to say (i mod 5 na 0)
         start
             shout("FizzBuzz")
         end
@@ -15,7 +15,7 @@ start
     end
     if not so
     start
-        if to say (i remain 5 na 0)
+        if to say (i mod 5 na 0)
         start
             shout("Buzz")
         end

--- a/examples/fizzbuzz.ns
+++ b/examples/fizzbuzz.ns
@@ -1,26 +1,19 @@
 make i get 1
 
-jasi (i small pass 101)
-start
-    if to say (i mod 3 na 0)
-    start
-        if to say (i mod 5 na 0)
-        start
+jasi (i small pass 101) start
+    if to say (i mod 3 na 0) start
+        if to say (i mod 5 na 0) start
             shout("FizzBuzz")
         end
-        if not so
-        start
+        if not so start
             shout("Fizz")
         end
     end
-    if not so
-    start
-        if to say (i mod 5 na 0)
-        start
+    if not so start
+        if to say (i mod 5 na 0) start
             shout("Buzz")
         end
-        if not so
-        start
+        if not so start
             shout(i)
         end
     end

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -284,7 +284,7 @@ impl<'src> SemAnalyzer<'src> {
                         }
                         _ => {}
                     },
-                    BinOp::Minus | BinOp::Times | BinOp::Divide | BinOp::Remain => match (l, r) {
+                    BinOp::Minus | BinOp::Times | BinOp::Divide | BinOp::Mod => match (l, r) {
                         (Some(VarType::Number), Some(VarType::Number)) => {}
                         (Some(VarType::String), Some(VarType::String)) => {
                             self.errors.emit(
@@ -294,7 +294,7 @@ impl<'src> SemAnalyzer<'src> {
                                 SemanticError::InvalidStringOperation.as_str(),
                                 vec![Label {
                                     span: span.clone(),
-                                    message: "You no fit minus/times/divide/remain string for here",
+                                    message: "You no fit minus/times/divide/mod string for here",
                                 }],
                             );
                         }
@@ -343,7 +343,7 @@ impl<'src> SemAnalyzer<'src> {
                 let l = self.infer_expr_type(*lhs)?;
                 let r = self.infer_expr_type(*rhs)?;
                 match op {
-                    BinOp::Add | BinOp::Minus | BinOp::Times | BinOp::Divide | BinOp::Remain => {
+                    BinOp::Add | BinOp::Minus | BinOp::Times | BinOp::Divide | BinOp::Mod => {
                         if l == VarType::Number && r == VarType::Number {
                             Some(VarType::Number)
                         } else if l == VarType::String

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -262,13 +262,13 @@ impl<'src> Interpreter<'src> {
                         BinOp::Add => Ok(Value::Number(lv + rv)),
                         BinOp::Minus => Ok(Value::Number(lv - rv)),
                         BinOp::Times => Ok(Value::Number(lv * rv)),
-                        BinOp::Divide | BinOp::Remain => {
+                        BinOp::Divide | BinOp::Mod => {
                             if rv == 0.0 {
                                 Err(RuntimeError { kind: RuntimeErrorKind::DivisionByZero, span })
                             } else {
                                 Ok(Value::Number(match op {
                                     BinOp::Divide => lv / rv,
-                                    BinOp::Remain => lv % rv,
+                                    BinOp::Mod => lv % rv,
                                     _ => unreachable!("Unexpected binary operation for numbers"),
                                 }))
                             }

--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -62,7 +62,7 @@ pub enum BinOp {
     Minus,  // "minus" keyword
     Times,  // "times" keyword
     Divide, // "divide" keyword
-    Remain, // "remain" keyword
+    Mod,    // "mod" keyword
 }
 
 /// Comparison operators for conditions in if statements and loops.
@@ -714,7 +714,7 @@ impl<'src, I: Iterator<Item = SpannedToken<'src>>> Parser<'src, I> {
             let op = match &self.cur.token {
                 Token::Times => BinOp::Times,
                 Token::Divide => BinOp::Divide,
-                Token::Remain => BinOp::Remain,
+                Token::Mod => BinOp::Mod,
                 Token::Add => BinOp::Add,
                 Token::Minus => BinOp::Minus,
                 _ => break, // No more operators
@@ -722,8 +722,8 @@ impl<'src, I: Iterator<Item = SpannedToken<'src>>> Parser<'src, I> {
 
             // Set precedence levels - multiplication/division/modulus bind tighter than addition/subtraction
             let (l_bp, r_bp) = match op {
-                BinOp::Times | BinOp::Divide | BinOp::Remain => (20, 21), // Higher precedence
-                BinOp::Add | BinOp::Minus => (10, 11),                    // Lower precedence
+                BinOp::Times | BinOp::Divide | BinOp::Mod => (20, 21), // Higher precedence
+                BinOp::Add | BinOp::Minus => (10, 11),                 // Lower precedence
             };
 
             // If current operator has lower precedence than minimum, we're done

--- a/src/syntax/scanner.rs
+++ b/src/syntax/scanner.rs
@@ -41,7 +41,7 @@ pub enum Token<'input> {
     Minus,  // "minus" - subtraction
     Times,  // "times" - multiplication
     Divide, // "divide" - division
-    Remain, // "remain" - modulus
+    Mod,    // "mod" - modulus
 
     // I/O and control flow
     Shout, // "shout" - print to console
@@ -455,7 +455,7 @@ impl<'input> Lexer<'input> {
             "minus" => Token::Minus,
             "times" => Token::Times,
             "divide" => Token::Divide,
-            "remain" => Token::Remain,
+            "mod" => Token::Mod,
             "shout" => Token::Shout,
             "jasi" => Token::Jasi,
             "start" => Token::Start,

--- a/tests/resolver.rs
+++ b/tests/resolver.rs
@@ -71,7 +71,7 @@ fn test_string_number_comparison_in_loop() {
 
 #[test]
 fn test_string_modulus() {
-    assert_resolve!(r#"make x get "foo" remain "bar""#, SemanticError::InvalidStringOperation);
+    assert_resolve!(r#"make x get "foo" mod "bar""#, SemanticError::InvalidStringOperation);
 }
 
 #[test]

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -151,7 +151,7 @@ fn empty_string_concatenation() {
 
 #[test]
 fn modulus_by_zero() {
-    assert_runtime!("shout(5 remain 0)", error: RuntimeErrorKind::DivisionByZero);
+    assert_runtime!("shout(5 mod 0)", error: RuntimeErrorKind::DivisionByZero);
 }
 
 #[test]

--- a/tests/scanner.rs
+++ b/tests/scanner.rs
@@ -18,7 +18,7 @@ macro_rules! assert_tokens {
 
 #[test]
 fn test_scan_keywords() {
-    let src = "make get add minus times divide remain shout jasi start end na pass small pass if to say if not so true false";
+    let src = "make get add minus times divide mod shout jasi start end na pass small pass if to say if not so true false";
     assert_tokens!(
         Lexer::new(src),
         Token::Make,
@@ -27,7 +27,7 @@ fn test_scan_keywords() {
         Token::Minus,
         Token::Times,
         Token::Divide,
-        Token::Remain,
+        Token::Mod,
         Token::Shout,
         Token::Jasi,
         Token::Start,


### PR DESCRIPTION
## Pull Request Overview

This PR renames the modulus operator keyword from `remain` to `mod` across the codebase to standardize terminology.

- Updated scanner, parser, resolver, and runtime logic to recognize `mod` instead of `remain`
- Updated tests and examples to use `mod`
- Updated grammar and language reference documentation