### PR TITLE
Add support for single line comments

### DIFF
--- a/docs/LRM.md
+++ b/docs/LRM.md
@@ -52,9 +52,11 @@ Literals na the fixed values wey you dey write directly for your code.
 
 - `(` and `)`: Used for grouping expressions and in `shout`, `if to say`, and `jasi` statements.
 
-### 2.6. Whitespace
+### 2.6. Whitespace and Comments
 
-Whitespace (spaces, tabs, newlines) dey used to separate tokens and make code readable. NaijaScript no dey sensitive to whitespace.
+Whitespace (like space, tab, or new line) na wetin you fit use to separate code make e clear. NaijaScript no dey worry about how many space or new line you put.
+
+If you wan write comment, just put `#` for anywhere for the line. Anything wey dey after `#` till the end of that line na comment, the interpreter no go run am. You fit put comment anywhere for your code, e no go affect how your program work.
 
 ## 3. Grammar and Syntax
 

--- a/docs/grammar.bnf
+++ b/docs/grammar.bnf
@@ -38,3 +38,5 @@
 <condition> ::= <expression> "na" <expression> | <expression> "pass" <expression> | <expression> "small pass" <expression>
 
 <block> ::= "start" <statement_list> "end"
+
+<comment> ::= "#" { any character except "\n" }

--- a/examples/fibonacci.ns
+++ b/examples/fibonacci.ns
@@ -1,10 +1,19 @@
-make a get 0
-make b get 1
-make i get 0
+# This program calculates the first 10 numbers in the Fibonacci sequence
+# The Fibonacci sequence starts with 0, 1 and each next number is the sum of the previous two
+
+make a get 0  # Initialize first Fibonacci number to 0
+make b get 1  # Initialize second Fibonacci number to 1
+make i get 0  # Initialize loop counter to 0
+
+# Loop while counter is less than 10 to generate 10 Fibonacci numbers
 jasi ( i small pass 10 ) start
-    shout ( a )
+    shout ( a )  # Print the current Fibonacci number
+    
+    # Calculate the next Fibonacci number by adding current two numbers
     make temp get a add b
-    a get b
-    b get temp
-    i get i add 1
+    
+    a get b      # Move second number to first position
+    b get temp   # Move calculated sum to second position
+    i get i add 1  # Increment counter by 1
 end
+# After loop completes, we have printed the first 10 Fibonacci numbers

--- a/src/syntax/scanner.rs
+++ b/src/syntax/scanner.rs
@@ -117,6 +117,19 @@ impl<'input> Lexer<'input> {
             // Skip over any whitespace before the next token
             self.skip_whitespace();
 
+            // If we see a '#' character, that means the start of a comment, so let's skip everything until we hit a newline or the end of the input
+            if self.peek() == b'#' {
+                while self.peek() != b'\n' && self.peek() != 0 {
+                    self.bump();
+                }
+                // After skipping to end of line, we might be sitting on the newline character
+                // We need to consume it too so the next token scan starts fresh on the following line
+                if self.peek() == b'\n' {
+                    self.bump();
+                }
+                continue;
+            }
+
             // Record starting position for spans and slicing
             let start = self.pos;
 

--- a/src/syntax/scanner.rs
+++ b/src/syntax/scanner.rs
@@ -117,8 +117,10 @@ impl<'input> Lexer<'input> {
             // Skip over any whitespace before the next token
             self.skip_whitespace();
 
+            let b = self.peek();
+
             // If we see a '#' character, that means the start of a comment.
-            if self.peek() == b'#' {
+            if b == b'#' {
                 self.skip_comment();
                 continue;
             }
@@ -127,7 +129,6 @@ impl<'input> Lexer<'input> {
             let start = self.pos;
 
             // Check for EOF first
-            let b = self.peek();
             if b == 0 {
                 return SpannedToken { token: Token::EOF, span: start..start };
             }

--- a/src/syntax/scanner.rs
+++ b/src/syntax/scanner.rs
@@ -117,16 +117,9 @@ impl<'input> Lexer<'input> {
             // Skip over any whitespace before the next token
             self.skip_whitespace();
 
-            // If we see a '#' character, that means the start of a comment, so let's skip everything until we hit a newline (LF), carriage return (CR), or the end of the input
+            // If we see a '#' character, that means the start of a comment.
             if self.peek() == b'#' {
-                while self.peek() != b'\n' && self.peek() != b'\r' && self.peek() != 0 {
-                    self.bump();
-                }
-                // After skipping to end of line, we might be sitting on the newline or carriage return character
-                // We need to consume it too so the next token scan starts fresh on the following line
-                if self.peek() == b'\n' || self.peek() == b'\r' {
-                    self.bump();
-                }
+                self.skip_comment();
                 continue;
             }
 
@@ -192,6 +185,19 @@ impl<'input> Lexer<'input> {
     #[inline(always)]
     fn skip_whitespace(&mut self) {
         while self.peek().is_ascii_whitespace() {
+            self.bump();
+        }
+    }
+
+    #[inline(always)]
+    fn skip_comment(&mut self) {
+        // Let's keep moving forward until we find a newline, a carriage return, or reach the end of the input. This way, we skip the whole comment and get ready to scan the next real token.
+        while self.peek() != b'\n' && self.peek() != b'\r' && self.peek() != 0 {
+            self.bump();
+        }
+        // After skipping to end of line, we might be sitting on the newline or carriage return character
+        // We need to consume it too so the next token scan starts fresh on the following line
+        if self.peek() == b'\n' || self.peek() == b'\r' {
             self.bump();
         }
     }

--- a/src/syntax/scanner.rs
+++ b/src/syntax/scanner.rs
@@ -117,14 +117,14 @@ impl<'input> Lexer<'input> {
             // Skip over any whitespace before the next token
             self.skip_whitespace();
 
-            // If we see a '#' character, that means the start of a comment, so let's skip everything until we hit a newline or the end of the input
+            // If we see a '#' character, that means the start of a comment, so let's skip everything until we hit a newline (LF), carriage return (CR), or the end of the input
             if self.peek() == b'#' {
-                while self.peek() != b'\n' && self.peek() != 0 {
+                while self.peek() != b'\n' && self.peek() != b'\r' && self.peek() != 0 {
                     self.bump();
                 }
-                // After skipping to end of line, we might be sitting on the newline character
+                // After skipping to end of line, we might be sitting on the newline or carriage return character
                 // We need to consume it too so the next token scan starts fresh on the following line
-                if self.peek() == b'\n' {
+                if self.peek() == b'\n' || self.peek() == b'\r' {
                     self.bump();
                 }
                 continue;

--- a/tests/scanner.rs
+++ b/tests/scanner.rs
@@ -224,3 +224,43 @@ fn test_scan_unexpected_character() {
     assert_eq!(label.span, 0..0);
     assert!(errors.diagnostics.iter().any(|e| e.message == LexError::UnexpectedChar.as_str()));
 }
+
+#[test]
+fn test_scan_single_line_comment() {
+    let src = "# this is a comment";
+    assert_tokens!(Lexer::new(src), Token::EOF);
+}
+
+#[test]
+fn test_scan_full_line_comment() {
+    let src = r#"
+        make x get 1
+        # full line comment
+        make y get 2
+    "#;
+    assert_tokens!(
+        Lexer::new(src),
+        Token::Make,
+        Token::Identifier("x"),
+        Token::Get,
+        Token::Number("1"),
+        Token::Make,
+        Token::Identifier("y"),
+        Token::Get,
+        Token::Number("2"),
+        Token::EOF
+    );
+}
+
+#[test]
+fn test_scan_trailing_comment() {
+    let src = "make x get 1 # trailing comment";
+    assert_tokens!(
+        Lexer::new(src),
+        Token::Make,
+        Token::Identifier("x"),
+        Token::Get,
+        Token::Number("1"),
+        Token::EOF
+    );
+}


### PR DESCRIPTION
## Pull Request Overview

This PR introduces single-line comment support using `#`, ensuring comments are skipped by the lexer, tested, and documented.

- Implement comment skipping in the lexer
- Add tests for single-line, full-line, and trailing comments
- Update grammar, language reference, and examples to include comment syntax