### PR TITLE
Add support for logical operators

### DIFF
--- a/docs/LRM.md
+++ b/docs/LRM.md
@@ -30,6 +30,7 @@ Keywords na special words wey get meaning for NaijaScript. You no fit use them a
 - `end`: End of a code block.
 - `add`, `minus`, `times`, `divide`, `mod`: Arithmetic operators.
 - `na`, `pass`, `small pass`: Comparison operators.
+- `and`, `or`, `not`: Logical operators.
 
 ### 2.3. Literals
 
@@ -47,6 +48,16 @@ Literals na the fixed values wey you dey write directly for your code.
 
 - **Arithmetic**: `add` (+), `minus` (-), `times` (\*), `divide` (/), `mod` (%)
 - **Comparison**: `na` (==), `pass` (>), `small pass` (<)
+- **Logical**: `and` (logical AND), `or` (logical OR), `not` (logical NOT)
+
+**Operator Precedence (from highest to lowest):**
+
+1. `not`
+2. `times`, `divide`, `mod`
+3. `add`, `minus`
+4. `na`, `pass`, `small pass`
+5. `and`
+6. `or`
 
 ### 2.5. Punctuation
 
@@ -102,6 +113,7 @@ This section dey explain wetin each part of the language dey do when e dey run.
 - **Arithmetic**: Expressions with `add`, `minus`, `times`, `divide`, and `mod` go perform the calculation and return a `Number`. If you try to divide by zero or use mod with zero, e go cause a runtime error.
 - **String Concatenation**: You fit use the `add` operator to join two strings together.
 - **Comparison**: Expressions with `na`, `pass`, and `small pass` go compare two values and return a boolean result (true or false) for use in conditions.
+- **Logical**: Expressions wey use `and`, `or`, and `not` dey join or change boolean values. Dem only work if the values na `true` or `false`. If you try use dem with number or string, e go cause a semantic error.
 
 ## 6. Built-in Intrinsics
 

--- a/docs/grammar.bnf
+++ b/docs/grammar.bnf
@@ -15,7 +15,9 @@
 
 <digit> ::= "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
 
-<expression> ::= <term> | <expression> "add" <term> | <expression> "minus" <term>
+<expression> ::= <logic_term> | <expression> "or" <logic_term> | <expression> "add" <term> | <expression> "minus" <term>
+<logic_term> ::= <logic_factor> | <logic_term> "and" <logic_factor> | <term>
+<logic_factor> ::= "not" <factor> | <factor>
 
 <term> ::= <factor> | <term> "times" <factor> | <term> "divide" <factor> | <term> "mod" <factor>
 

--- a/src/syntax/scanner.rs
+++ b/src/syntax/scanner.rs
@@ -43,6 +43,11 @@ pub enum Token<'input> {
     Divide, // "divide" - division
     Mod,    // "mod" - modulus
 
+    // Logical operators
+    And, // "and" - logical and
+    Or,  // "or" - logical or
+    Not, // "not" - logical not
+
     // I/O and control flow
     Shout, // "shout" - print to console
     Jasi,  // "jasi" - while loop construct (Nigerian slang for "keep going")
@@ -476,6 +481,9 @@ impl<'input> Lexer<'input> {
             "times" => Token::Times,
             "divide" => Token::Divide,
             "mod" => Token::Mod,
+            "and" => Token::And,
+            "or" => Token::Or,
+            "not" => Token::Not,
             "shout" => Token::Shout,
             "jasi" => Token::Jasi,
             "start" => Token::Start,

--- a/tests/resolver.rs
+++ b/tests/resolver.rs
@@ -98,3 +98,23 @@ fn test_block_scope_variable_not_visible_outside() {
 fn test_block_scope_duplicate_in_same_block() {
     assert_resolve!("start make x get 1 make x get 2 end", SemanticError::DuplicateDeclaration);
 }
+
+#[test]
+fn test_logical_and_type_error() {
+    assert_resolve!("make x get true and 1", SemanticError::TypeMismatch);
+    assert_resolve!("make x get 1 and true", SemanticError::TypeMismatch);
+    assert_resolve!("make x get 1 and 2", SemanticError::TypeMismatch);
+}
+
+#[test]
+fn test_logical_or_type_error() {
+    assert_resolve!("make x get true or 1", SemanticError::TypeMismatch);
+    assert_resolve!("make x get 1 or true", SemanticError::TypeMismatch);
+    assert_resolve!("make x get 1 or 2", SemanticError::TypeMismatch);
+}
+
+#[test]
+fn test_logical_not_type_error() {
+    assert_resolve!("make x get not 1", SemanticError::TypeMismatch);
+    assert_resolve!(r#"make x get not "foo""#, SemanticError::TypeMismatch);
+}

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -182,3 +182,37 @@ fn boolean_ordering() {
 fn block_scope_shadowing_and_lifetime() {
     assert_runtime!("make x get 1 start make x get 2 shout(x) end shout(x)", output: vec![Value::Number(2.0), Value::Number(1.0)]);
 }
+
+#[test]
+fn logical_and_operator() {
+    assert_runtime!("shout(true and true)", output: vec![Value::Bool(true)]);
+    assert_runtime!("shout(true and false)", output: vec![Value::Bool(false)]);
+    assert_runtime!("shout(false and true)", output: vec![Value::Bool(false)]);
+    assert_runtime!("shout(false and false)", output: vec![Value::Bool(false)]);
+}
+
+#[test]
+fn logical_or_operator() {
+    assert_runtime!("shout(true or true)", output: vec![Value::Bool(true)]);
+    assert_runtime!("shout(true or false)", output: vec![Value::Bool(true)]);
+    assert_runtime!("shout(false or true)", output: vec![Value::Bool(true)]);
+    assert_runtime!("shout(false or false)", output: vec![Value::Bool(false)]);
+}
+
+#[test]
+fn logical_not_operator() {
+    assert_runtime!("shout(not true)", output: vec![Value::Bool(false)]);
+    assert_runtime!("shout(not false)", output: vec![Value::Bool(true)]);
+}
+
+#[test]
+fn logical_operator_precedence() {
+    assert_runtime!("shout(true or false and false)", output: vec![Value::Bool(true)]);
+    assert_runtime!("shout((true or false) and false)", output: vec![Value::Bool(false)]);
+}
+
+#[test]
+fn logical_not_precedence() {
+    assert_runtime!("shout(not true or true)", output: vec![Value::Bool(true)]);
+    assert_runtime!("shout(not (true or true))", output: vec![Value::Bool(false)]);
+}

--- a/tests/scanner.rs
+++ b/tests/scanner.rs
@@ -18,7 +18,7 @@ macro_rules! assert_tokens {
 
 #[test]
 fn test_scan_keywords() {
-    let src = "make get add minus times divide mod shout jasi start end na pass small pass if to say if not so true false";
+    let src = "make get add minus times divide mod shout jasi start end na pass small pass if to say if not so true false and not or";
     assert_tokens!(
         Lexer::new(src),
         Token::Make,
@@ -39,6 +39,9 @@ fn test_scan_keywords() {
         Token::IfNotSo,
         Token::True,
         Token::False,
+        Token::And,
+        Token::Not,
+        Token::Or,
         Token::EOF
     );
 }


### PR DESCRIPTION
## Pull Request Overview

Adds full support for logical operators (`and`, `or`, `not`) by extending the scanner, parser, semantic resolver, interpreter, tests, and documentation.

- Scanner now tokenizes `and`, `or`, `not`.
- Parser handles binary logical operators with correct precedence and introduces a unary `not` AST node.
- Semantic analyzer and interpreter enforce boolean-only usage with short-circuit evaluation.
- Added tests for scanning, parsing, resolution, and runtime behavior; updated BNF and language reference.