### PR TITLE
Refactor token handling and improve error messages

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -2,7 +2,8 @@ use std::hint::black_box;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use naijascript::syntax::parser::Parser;
-use naijascript::syntax::scanner::{Lexer, Token};
+use naijascript::syntax::scanner::Lexer;
+use naijascript::syntax::token::Token;
 
 fn bench_lexer(c: &mut Criterion) {
     let input = black_box(

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,5 +1,6 @@
 //! The diagnostics system for NaijaScript.
 
+use std::borrow::Cow;
 use std::ops::Range;
 
 /// Byte-range span within source text.
@@ -51,7 +52,7 @@ impl Severity {
 #[derive(Debug)]
 pub struct Label {
     pub span: Span,
-    pub message: &'static str,
+    pub message: Cow<'static, str>,
 }
 
 #[derive(Debug)]
@@ -117,7 +118,7 @@ impl Diagnostics {
                     lbl_col,
                     dash_count,
                     color,
-                    label.message,
+                    &label.message,
                     &plain_gutter,
                 ));
             }
@@ -135,7 +136,7 @@ impl Diagnostics {
                     label_col,
                     dash_count,
                     color,
-                    label.message,
+                    &label.message,
                     &plain_gutter,
                 );
                 cross_line_displays.push((line_display, label_underline));

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -125,10 +125,13 @@ impl<'src> Interpreter<'src> {
                 let labels = match err.kind {
                     RuntimeErrorKind::DivisionByZero => vec![Label {
                         span: err.span.clone(),
-                        message: "You divide by zero for here",
+                        message: Cow::Borrowed("You divide by zero for here"),
                     }],
                     RuntimeErrorKind::InvalidNumber => {
-                        vec![Label { span: err.span.clone(), message: "This number no correct" }]
+                        vec![Label {
+                            span: err.span.clone(),
+                            message: Cow::Borrowed("This number no correct"),
+                        }]
                     }
                 };
                 self.errors.emit(

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -1,2 +1,3 @@
 pub mod parser;
 pub mod scanner;
+pub mod token;

--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -322,7 +322,7 @@ impl<'src, I: Iterator<Item = SpannedToken<'src>>> Parser<'src, I> {
                     let message: Cow<'static, str> =
                         if let Some(suggestion) = Token::suggest_keyword(var_name) {
                             Cow::Owned(format!(
-                                "I dey expect statement for here. Na `{suggestion}` you mean ?",
+                                "I dey expect statement for here. Na `{suggestion}` you mean?",
                             ))
                         } else {
                             Cow::Borrowed("I dey expect statement for here")

--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -3,7 +3,7 @@
 use std::borrow::Cow;
 
 use crate::diagnostics::{AsStr, Diagnostics, Label, Severity, Span};
-use crate::syntax::scanner::{SpannedToken, Token};
+use crate::syntax::token::{SpannedToken, Token};
 
 /// Arena allocator for AST nodes - our answer to memory management without garbage collection.
 ///
@@ -294,7 +294,7 @@ impl<'src, I: Iterator<Item = SpannedToken<'src>>> Parser<'src, I> {
                         SyntaxError::UnterminatedBlock.as_str(),
                         vec![Label {
                             span: self.cur.span.clone(),
-                            message: "Dis block start here, but I no see `end`",
+                            message: Cow::Borrowed("Dis block start here, but I no see `end`"),
                         }],
                     );
                 }
@@ -319,17 +319,14 @@ impl<'src, I: Iterator<Item = SpannedToken<'src>>> Parser<'src, I> {
                     Some(sid)
                 } else {
                     // Not a reassignment, error and do not consume
-                    let mut message = "I dey expect statement for here";
-                    // Suggest a keyword if close to a known one
-                    if Self::suggest_keyword(var_name, "make").is_some() {
-                        message = "You fit mean `make`?";
-                    } else if Self::suggest_keyword(var_name, "shout").is_some() {
-                        message = "You fit mean `shout`?";
-                    } else if Self::suggest_keyword(var_name, "jasi").is_some() {
-                        message = "You fit mean `jasi`?";
-                    } else if Self::suggest_keyword(var_name, "if").is_some() {
-                        message = "You fit mean `if to say`?";
-                    }
+                    let message: Cow<'static, str> =
+                        if let Some(suggestion) = Token::suggest_keyword(var_name) {
+                            Cow::Owned(format!(
+                                "I dey expect statement for here. Na `{suggestion}` you mean ?",
+                            ))
+                        } else {
+                            Cow::Borrowed("I dey expect statement for here")
+                        };
                     self.errors.emit(
                         var_span.clone(),
                         Severity::Error,
@@ -348,7 +345,7 @@ impl<'src, I: Iterator<Item = SpannedToken<'src>>> Parser<'src, I> {
                     SyntaxError::ExpectedStatement.as_str(),
                     vec![Label {
                         span: self.cur.span.clone(),
-                        message: "I dey expect `make`, `shout`, `if to say`, `jasi`, or variable reassignment for here",
+                        message: Cow::Borrowed("I dey expect `make`, `shout`, `if to say`, `jasi`, or variable reassignment for here"),
                     }],
                 );
                 None
@@ -375,7 +372,7 @@ impl<'src, I: Iterator<Item = SpannedToken<'src>>> Parser<'src, I> {
                 SyntaxError::ExpectedIdentifierAfterMake.as_str(),
                 vec![Label {
                     span: self.cur.span.clone(),
-                    message: "Put variable name after `make` for here",
+                    message: Cow::Borrowed("Put variable name after `make` for here"),
                 }],
             );
             return None;
@@ -391,7 +388,7 @@ impl<'src, I: Iterator<Item = SpannedToken<'src>>> Parser<'src, I> {
                 SyntaxError::ExpectedGetAfterIdentifier.as_str(),
                 vec![Label {
                     span: self.cur.span.clone(),
-                    message: "Put `get` after variable name for here",
+                    message: Cow::Borrowed("Put `get` after variable name for here"),
                 }],
             );
             return None;
@@ -418,7 +415,7 @@ impl<'src, I: Iterator<Item = SpannedToken<'src>>> Parser<'src, I> {
                 SyntaxError::ExpectedLParenAfterShout.as_str(),
                 vec![Label {
                     span: self.cur.span.clone(),
-                    message: "Put `(` after `shout` for here",
+                    message: Cow::Borrowed("Put `(` after `shout` for here"),
                 }],
             );
             return None;
@@ -434,7 +431,7 @@ impl<'src, I: Iterator<Item = SpannedToken<'src>>> Parser<'src, I> {
                 SyntaxError::ExpectedRParenAfterShout.as_str(),
                 vec![Label {
                     span: self.cur.span.clone(),
-                    message: "Close shout with `)` for here",
+                    message: Cow::Borrowed("Close shout with `)` for here"),
                 }],
             );
             return None;
@@ -460,7 +457,7 @@ impl<'src, I: Iterator<Item = SpannedToken<'src>>> Parser<'src, I> {
                 SyntaxError::ExpectedLParenAfterIf.as_str(),
                 vec![Label {
                     span: self.cur.span.clone(),
-                    message: "Put `(` after `if to say` for here",
+                    message: Cow::Borrowed("Put `(` after `if to say` for here"),
                 }],
             );
             return None;
@@ -476,7 +473,7 @@ impl<'src, I: Iterator<Item = SpannedToken<'src>>> Parser<'src, I> {
                 SyntaxError::ExpectedRParenAfterIf.as_str(),
                 vec![Label {
                     span: self.cur.span.clone(),
-                    message: "Close condition with `)` for here",
+                    message: Cow::Borrowed("Close condition with `)` for here"),
                 }],
             );
             return None;
@@ -493,7 +490,7 @@ impl<'src, I: Iterator<Item = SpannedToken<'src>>> Parser<'src, I> {
                 SyntaxError::ExpectedStartForThenBlock.as_str(),
                 vec![Label {
                     span: self.cur.span.clone(),
-                    message: "Begin block with `start` for here",
+                    message: Cow::Borrowed("Begin block with `start` for here"),
                 }],
             );
             return None;
@@ -509,7 +506,7 @@ impl<'src, I: Iterator<Item = SpannedToken<'src>>> Parser<'src, I> {
                 SyntaxError::UnterminatedThenBlock.as_str(),
                 vec![Label {
                     span: self.cur.span.clone(),
-                    message: "Dis block start here, but I no see `end`",
+                    message: Cow::Borrowed("Dis block start here, but I no see `end`"),
                 }],
             );
         }
@@ -528,7 +525,7 @@ impl<'src, I: Iterator<Item = SpannedToken<'src>>> Parser<'src, I> {
                     SyntaxError::ExpectedStartForElseBlock.as_str(),
                     vec![Label {
                         span: self.cur.span.clone(),
-                        message: "Begin else block with `start` for here",
+                        message: Cow::Borrowed("Begin else block with `start` for here"),
                     }],
                 );
                 return None;
@@ -544,7 +541,7 @@ impl<'src, I: Iterator<Item = SpannedToken<'src>>> Parser<'src, I> {
                     SyntaxError::UnterminatedElseBlock.as_str(),
                     vec![Label {
                         span: else_span,
-                        message: "Dis else block start here, but I no see `end`",
+                        message: Cow::Borrowed("Dis else block start here, but I no see `end`"),
                     }],
                 );
             }
@@ -578,7 +575,7 @@ impl<'src, I: Iterator<Item = SpannedToken<'src>>> Parser<'src, I> {
                 SyntaxError::ExpectedLParenAfterJasi.as_str(),
                 vec![Label {
                     span: self.cur.span.clone(),
-                    message: "Put `(` after `jasi` for here",
+                    message: Cow::Borrowed("Put `(` after `jasi` for here"),
                 }],
             );
             return None;
@@ -594,7 +591,7 @@ impl<'src, I: Iterator<Item = SpannedToken<'src>>> Parser<'src, I> {
                 SyntaxError::ExpectedRParenAfterJasi.as_str(),
                 vec![Label {
                     span: self.cur.span.clone(),
-                    message: "Close loop condition with `)` for here",
+                    message: Cow::Borrowed("Close loop condition with `)` for here"),
                 }],
             );
             return None;
@@ -609,7 +606,7 @@ impl<'src, I: Iterator<Item = SpannedToken<'src>>> Parser<'src, I> {
                 SyntaxError::ExpectedStartForLoopBody.as_str(),
                 vec![Label {
                     span: self.cur.span.clone(),
-                    message: "Begin loop body with `start` for here",
+                    message: Cow::Borrowed("Begin loop body with `start` for here"),
                 }],
             );
             return None;
@@ -625,7 +622,7 @@ impl<'src, I: Iterator<Item = SpannedToken<'src>>> Parser<'src, I> {
                 SyntaxError::UnterminatedLoopBody.as_str(),
                 vec![Label {
                     span: self.cur.span.clone(),
-                    message: "Dis loop body start here, but I no see `end`",
+                    message: Cow::Borrowed("Dis loop body start here, but I no see `end`"),
                 }],
             );
         }
@@ -652,7 +649,9 @@ impl<'src, I: Iterator<Item = SpannedToken<'src>>> Parser<'src, I> {
                     SyntaxError::ExpectedComparisonOperator.as_str(),
                     vec![Label {
                         span: self.cur.span.clone(),
-                        message: "Use `na`, `pass`, or `small pass` to compare for here",
+                        message: Cow::Borrowed(
+                            "Use `na`, `pass`, or `small pass` to compare for here",
+                        ),
                     }],
                 );
                 CmpOp::Eq // fallback to something reasonable
@@ -721,7 +720,7 @@ impl<'src, I: Iterator<Item = SpannedToken<'src>>> Parser<'src, I> {
                         SyntaxError::ExpectedNumberOrVariableOrLParen.as_str(),
                         vec![Label {
                             span: self.cur.span.clone(),
-                            message: "Close expression with `)` for here",
+                            message: Cow::Borrowed("Close expression with `)` for here"),
                         }],
                     );
                 }
@@ -735,7 +734,7 @@ impl<'src, I: Iterator<Item = SpannedToken<'src>>> Parser<'src, I> {
                     SyntaxError::ExpectedNumberOrVariableOrLParen.as_str(),
                     vec![Label {
                         span: self.cur.span.clone(),
-                        message: "I dey expect number, variable, or ( for here",
+                        message: Cow::Borrowed("I dey expect number, variable, or `(` for here"),
                     }],
                 );
                 let s = self.cur.span.clone();
@@ -772,34 +771,6 @@ impl<'src, I: Iterator<Item = SpannedToken<'src>>> Parser<'src, I> {
             });
         }
         lhs
-    }
-
-    /// Suggests a statement keyword if the identifier is a likely typo, using a single-edit heuristic.
-    #[inline]
-    fn suggest_keyword<'a>(ident: &str, expected: &'a str) -> Option<&'a str> {
-        // Only check for single-char edit distance or prefix (very cheap, no alloc)
-        if ident.len() == expected.len() {
-            // One substitution: e.g., 'mak' vs 'make'
-            let mut diff = 0;
-            for (a, b) in ident.bytes().zip(expected.bytes()) {
-                if a != b {
-                    diff += 1;
-                    if diff > 1 {
-                        break;
-                    }
-                }
-            }
-            if diff == 1 {
-                return Some(expected);
-            }
-        } else if ident.len() + 1 == expected.len() && expected.starts_with(ident) {
-            // Missing last char: e.g., 'mak' vs 'make'
-            return Some(expected);
-        } else if ident.len() == expected.len() + 1 && ident.starts_with(expected) {
-            // Extra last char: e.g., 'makee' vs 'make'
-            return Some(expected);
-        }
-        None
     }
 
     /// Parses a program-level statement list that stops at invalid tokens.

--- a/src/syntax/scanner.rs
+++ b/src/syntax/scanner.rs
@@ -260,7 +260,7 @@ impl<'input> Lexer<'input> {
                             LexError::InvalidStringEscape.as_str(),
                             vec![Label {
                                 span: end..end + 2,
-                                message: Cow::Owned(format!("Dis escape `{esc}` no correct")),
+                                message: Cow::Borrowed("Dis escape no correct"),
                             }],
                         );
                         // Append the invalid escape character

--- a/src/syntax/scanner.rs
+++ b/src/syntax/scanner.rs
@@ -18,10 +18,10 @@ pub enum LexError {
 impl AsStr for LexError {
     fn as_str(&self) -> &'static str {
         match self {
-            LexError::UnexpectedChar => "Wetin be dis?",
-            LexError::InvalidNumber => "Dis number no correct",
-            LexError::InvalidIdentifier => "Dis name no correct",
-            LexError::InvalidStringEscape => "Dis escape no make sense",
+            LexError::UnexpectedChar => "Unexpected character",
+            LexError::InvalidNumber => "Number no correct",
+            LexError::InvalidIdentifier => "Identifier no correct",
+            LexError::InvalidStringEscape => "String escape no correct",
             LexError::UnterminatedString => "String never close",
         }
     }
@@ -240,7 +240,7 @@ impl<'input> Lexer<'input> {
                         LexError::UnterminatedString.as_str(),
                         vec![Label {
                             span: start..self.src.len(),
-                            message: Cow::Borrowed(r#"String no get ending quote `"`"#),
+                            message: Cow::Borrowed(r#"Dis string no get ending quote `"`"#),
                         }],
                     );
                     self.pos = self.src.len();
@@ -284,7 +284,7 @@ impl<'input> Lexer<'input> {
             LexError::UnterminatedString.as_str(),
             vec![Label {
                 span: start..self.src.len(),
-                message: Cow::Borrowed(r#"String no get ending quote `"`"#),
+                message: Cow::Borrowed(r#"Dis string no get ending quote `"`"#),
             }],
         );
         self.pos = self.src.len();
@@ -335,7 +335,7 @@ impl<'input> Lexer<'input> {
                     LexError::InvalidNumber.as_str(),
                     vec![Label {
                         span: dot_pos..self.pos,
-                        message: Cow::Borrowed("Number no get digit after `.`"),
+                        message: Cow::Borrowed("Dis number no get digit after `.`"),
                     }],
                 );
                 self.bump();
@@ -357,7 +357,7 @@ impl<'input> Lexer<'input> {
                 LexError::InvalidNumber.as_str(),
                 vec![Label {
                     span: extra_dot..self.pos,
-                    message: Cow::Borrowed("Number get extra `.`"),
+                    message: Cow::Borrowed("Dis number get extra `.`"),
                 }],
             );
             return self.next_token().token;
@@ -476,7 +476,9 @@ impl<'input> Lexer<'input> {
                                     LexError::InvalidIdentifier.as_str(),
                                     vec![Label {
                                         span: bad_pos..bad_pos + 1,
-                                        message: Cow::Borrowed("Identifier get invalid character"),
+                                        message: Cow::Borrowed(
+                                            "Dis identifier get invalid character",
+                                        ),
                                     }],
                                 );
                                 break;
@@ -499,7 +501,7 @@ impl<'input> Lexer<'input> {
             LexError::UnexpectedChar.as_str(),
             vec![Label {
                 span: start..self.pos,
-                message: Cow::Borrowed("Dis character no dey grammar"),
+                message: Cow::Borrowed("I no sabi dis character"),
             }],
         );
         None

--- a/src/syntax/scanner.rs
+++ b/src/syntax/scanner.rs
@@ -2,7 +2,8 @@
 
 use std::borrow::Cow;
 
-use crate::diagnostics::{AsStr, Diagnostics, Label, Severity, Span};
+use crate::diagnostics::{AsStr, Diagnostics, Label, Severity};
+use crate::syntax::token::{SpannedToken, Token};
 
 /// Represents the type of lexical errors that can occur during tokenization
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -24,68 +25,6 @@ impl AsStr for LexError {
             LexError::UnterminatedString => "String never close",
         }
     }
-}
-
-/// All possible token types in NaijaScript
-///
-/// The lifetime parameter 'input ties token references to the source text lifetime,
-/// letting us avoid copying strings for identifiers and numbers
-#[derive(Debug, Default, Clone, PartialEq)]
-pub enum Token<'input> {
-    // Keywords for variable declaration and assignment
-    Make, // "make" - variable declaration
-    Get,  // "get" - assignment operator
-
-    // Arithmetic operators
-    Add,    // "add" - addition
-    Minus,  // "minus" - subtraction
-    Times,  // "times" - multiplication
-    Divide, // "divide" - division
-    Mod,    // "mod" - modulus
-
-    // Logical operators
-    And, // "and" - logical and
-    Or,  // "or" - logical or
-    Not, // "not" - logical not
-
-    // I/O and control flow
-    Shout, // "shout" - print to console
-    Jasi,  // "jasi" - while loop construct (Nigerian slang for "keep going")
-    Start, // "start" - block beginning
-    End,   // "end" - block ending
-
-    // Comparison operators
-    Na,        // "na" - equality (Nigerian slang for "is")
-    Pass,      // "pass" - greater than (Nigerian slang for "exceeds")
-    SmallPass, // "small pass" - less than (Nigerian slang for "smaller than")
-
-    // Conditional constructs
-    IfToSay, // "if to say" - if statement
-    IfNotSo, // "if not so" - else statement
-
-    // Boolean literals
-    True,  // "true" - truthy
-    False, // "false" - falsy
-
-    // Punctuation
-    LParen, // "("
-    RParen, // ")"
-
-    // Variable length tokens
-    Identifier(&'input str),  // Variable names
-    Number(&'input str),      // Numeric literals
-    String(Cow<'input, str>), // String literals
-
-    // Special tokens
-    #[default]
-    EOF, // End of file
-}
-
-/// Represents a token along with its location in the original source text.
-#[derive(Debug, Default, Clone, PartialEq)]
-pub struct SpannedToken<'input> {
-    pub token: Token<'input>,
-    pub span: Span,
 }
 
 /// Our lexical analyzer that breaks source text into tokens
@@ -301,7 +240,7 @@ impl<'input> Lexer<'input> {
                         LexError::UnterminatedString.as_str(),
                         vec![Label {
                             span: start..self.src.len(),
-                            message: "String no get ending quote",
+                            message: Cow::Borrowed(r#"String no get ending quote `"`"#),
                         }],
                     );
                     self.pos = self.src.len();
@@ -319,7 +258,10 @@ impl<'input> Lexer<'input> {
                             Severity::Error,
                             "lexical",
                             LexError::InvalidStringEscape.as_str(),
-                            vec![Label { span: end..end + 2, message: "Escape wey no correct" }],
+                            vec![Label {
+                                span: end..end + 2,
+                                message: Cow::Owned(format!("Dis escape `{esc}` no correct")),
+                            }],
                         );
                         // Append the invalid escape character
                         owned.push(esc as char);
@@ -340,7 +282,10 @@ impl<'input> Lexer<'input> {
             Severity::Error,
             "lexical",
             LexError::UnterminatedString.as_str(),
-            vec![Label { span: start..self.src.len(), message: "String no get ending quote" }],
+            vec![Label {
+                span: start..self.src.len(),
+                message: Cow::Borrowed(r#"String no get ending quote `"`"#),
+            }],
         );
         self.pos = self.src.len();
         if has_escape {
@@ -390,7 +335,7 @@ impl<'input> Lexer<'input> {
                     LexError::InvalidNumber.as_str(),
                     vec![Label {
                         span: dot_pos..self.pos,
-                        message: "Number no get digit after dot",
+                        message: Cow::Borrowed("Number no get digit after `.`"),
                     }],
                 );
                 self.bump();
@@ -410,7 +355,10 @@ impl<'input> Lexer<'input> {
                 Severity::Error,
                 "lexical",
                 LexError::InvalidNumber.as_str(),
-                vec![Label { span: extra_dot..self.pos, message: "Number get extra dot" }],
+                vec![Label {
+                    span: extra_dot..self.pos,
+                    message: Cow::Borrowed("Number get extra `.`"),
+                }],
             );
             return self.next_token().token;
         }
@@ -428,7 +376,10 @@ impl<'input> Lexer<'input> {
                 Severity::Error,
                 "lexical",
                 LexError::InvalidIdentifier.as_str(),
-                vec![Label { span: start..id_start, message: "Identifier must start with letter" }],
+                vec![Label {
+                    span: start..id_start,
+                    message: Cow::Borrowed("Identifier must start with letter"),
+                }],
             );
             let num = &self.src[start..id_start];
             return Token::Number(num);
@@ -507,7 +458,7 @@ impl<'input> Lexer<'input> {
                             LexError::InvalidIdentifier.as_str(),
                             vec![Label {
                                 span: start..start + 1,
-                                message: "Identifier must start with letter",
+                                message: Cow::Borrowed("Identifier must start with letter"),
                             }],
                         );
                     } else {
@@ -525,7 +476,7 @@ impl<'input> Lexer<'input> {
                                     LexError::InvalidIdentifier.as_str(),
                                     vec![Label {
                                         span: bad_pos..bad_pos + 1,
-                                        message: "Identifier get invalid character",
+                                        message: Cow::Borrowed("Identifier get invalid character"),
                                     }],
                                 );
                                 break;
@@ -546,7 +497,10 @@ impl<'input> Lexer<'input> {
             Severity::Error,
             "lexical",
             LexError::UnexpectedChar.as_str(),
-            vec![Label { span: start..self.pos, message: "Dis character no dey grammar" }],
+            vec![Label {
+                span: start..self.pos,
+                message: Cow::Borrowed("Dis character no dey grammar"),
+            }],
         );
         None
     }

--- a/src/syntax/token.rs
+++ b/src/syntax/token.rs
@@ -1,0 +1,155 @@
+use std::borrow::Cow;
+
+use crate::diagnostics::Span;
+
+/// All possible token types in NaijaScript
+///
+/// The lifetime parameter 'input ties token references to the source text lifetime,
+/// letting us avoid copying strings for identifiers and numbers
+#[derive(Debug, Default, Clone, PartialEq)]
+pub enum Token<'input> {
+    // Keywords for variable declaration and assignment
+    Make, // "make" - variable declaration
+    Get,  // "get" - assignment operator
+
+    // Arithmetic operators
+    Add,    // "add" - addition
+    Minus,  // "minus" - subtraction
+    Times,  // "times" - multiplication
+    Divide, // "divide" - division
+    Mod,    // "mod" - modulus
+
+    // Logical operators
+    And, // "and" - logical and
+    Or,  // "or" - logical or
+    Not, // "not" - logical not
+
+    // I/O and control flow
+    Shout, // "shout" - print to console
+    Jasi,  // "jasi" - while loop construct (Nigerian slang for "keep going")
+    Start, // "start" - block beginning
+    End,   // "end" - block ending
+
+    // Comparison operators
+    Na,        // "na" - equality (Nigerian slang for "is")
+    Pass,      // "pass" - greater than (Nigerian slang for "exceeds")
+    SmallPass, // "small pass" - less than (Nigerian slang for "smaller than")
+
+    // Conditional constructs
+    IfToSay, // "if to say" - if statement
+    IfNotSo, // "if not so" - else statement
+
+    // Boolean literals
+    True,  // "true" - truthy
+    False, // "false" - falsy
+
+    // Punctuation
+    LParen, // "("
+    RParen, // ")"
+
+    // Variable length tokens
+    Identifier(&'input str),  // Variable names
+    Number(&'input str),      // Numeric literals
+    String(Cow<'input, str>), // String literals
+
+    // Special tokens
+    #[default]
+    EOF, // End of file
+}
+
+impl<'input> Token<'input> {
+    pub fn suggest_keyword(ident: &str) -> Option<&'static str> {
+        Self::all_keywords()
+            .iter()
+            .find(|&&kw| Self::is_single_edit(ident, kw))
+            .copied()
+            .map(|v| v as _)
+    }
+
+    // Returns a static list of all reserved keywords in NaijaScript.
+    #[inline(always)]
+    const fn all_keywords() -> &'static [&'static str] {
+        &[
+            "make",
+            "get",
+            "add",
+            "minus",
+            "times",
+            "divide",
+            "mod",
+            "shout",
+            "jasi",
+            "start",
+            "end",
+            "na",
+            "pass",
+            "small pass",
+            "if to say",
+            "if not so",
+            "true",
+            "false",
+            "and",
+            "not",
+            "or",
+        ]
+    }
+
+    // Checks if two strings differ by exactly one simple change: either a single character replaced, added, or removed.
+    #[inline]
+    fn is_single_edit(a: &str, b: &str) -> bool {
+        if a == b {
+            return false;
+        }
+        let a_bytes = a.as_bytes();
+        let b_bytes = b.as_bytes();
+        let (alen, blen) = (a_bytes.len(), b_bytes.len());
+        if alen == blen {
+            // Handles the case where only one character is different between the two strings
+            let mut diff = 0;
+            for (x, y) in a_bytes.iter().zip(b_bytes.iter()) {
+                if x != y {
+                    diff += 1;
+                    if diff > 1 {
+                        return false;
+                    }
+                }
+            }
+            diff == 1
+        } else if alen + 1 == blen {
+            // Handles when the second string has one extra character compared to the first
+            b.starts_with(a) || Self::is_one_insert(a_bytes, b_bytes)
+        } else if alen == blen + 1 {
+            // Handles when the first string has one extra character compared to the second
+            a.starts_with(b) || Self::is_one_insert(b_bytes, a_bytes)
+        } else {
+            false
+        }
+    }
+
+    #[inline]
+    const fn is_one_insert(short: &[u8], long: &[u8]) -> bool {
+        let mut i = 0;
+        let mut j = 0;
+        let mut found = false;
+        while i < short.len() && j < long.len() {
+            if short[i] != long[j] {
+                if found {
+                    return false;
+                }
+                found = true;
+                j += 1;
+            } else {
+                i += 1;
+                j += 1;
+            }
+        }
+        true
+    }
+}
+
+/// Represents a token along with its location in the original source text.
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct SpannedToken<'input> {
+    pub token: Token<'input>,
+    pub span: Span,
+}

--- a/tests/scanner.rs
+++ b/tests/scanner.rs
@@ -1,7 +1,8 @@
 use std::borrow::Cow;
 
 use naijascript::diagnostics::AsStr;
-use naijascript::syntax::scanner::{LexError, Lexer, Token};
+use naijascript::syntax::scanner::{LexError, Lexer};
+use naijascript::syntax::token::Token;
 
 macro_rules! assert_tokens {
     ($lexer:expr, $($expected:expr),+ $(,)?) => {{


### PR DESCRIPTION
## Pull Request Overview

This PR refactors token management by moving `Token` and `SpannedToken` into their own module and unifies diagnostics messages using `Cow<'static, str>` for greater flexibility and clearer formatting. Key changes include:
- Extracted and centralized the `Token` enum and suggestion logic in `src/syntax/token.rs`
- Updated all imports and removed duplicate token definitions in scanner and parser
- Standardized error messages to use `Cow` (borrowed or owned) with backticks and dynamic suggestions
