### PR TITLE
Add WASM support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "ansi-to-html"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12e283a4fc285735ef99577e81a125f738429516161ac33977e466d0d8d40764"
+dependencies = [
+ "regex",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,6 +1065,7 @@ dependencies = [
 name = "naijascript"
 version = "0.10.4"
 dependencies = [
+ "ansi-to-html",
  "clap",
  "clap-cargo",
  "criterion",
@@ -1225,7 +1236,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "web-time",
@@ -1246,7 +1257,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.12",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1347,7 +1358,7 @@ checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -1677,11 +1688,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.12",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,6 +649,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "html-escape"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
+dependencies = [
+ "utf8-width",
+]
+
+[[package]]
 name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,9 +1060,11 @@ dependencies = [
  "criterion",
  "dirs",
  "flate2",
+ "html-escape",
  "regex-lite",
  "reqwest",
  "tar",
+ "wasm-bindgen",
  "zip",
 ]
 
@@ -1252,7 +1263,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1861,6 +1872,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8-width"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,18 +4,36 @@ version = "0.10.4"
 edition = "2024"
 authors = ["Success Kingsley <xosnrdev@gmail.com>"]
 description = "A scripting language for learning, automation, and fun with Naija (Nigerian) lingo."
+repository = "https://github.com/xosnrdev/naijascript"
+license = "MIT"
+readme = false
+publish = false
 
 default-run = "naija"
+
+# These wasm-opt flags help avoid build errors when compiling with wasm-pack.
+# For more details, see: https://github.com/rustwasm/wasm-pack/issues/1441
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["--enable-bulk-memory", "--enable-nontrapping-float-to-int"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 clap = { version = "4.5.39", features = ["derive"] }
 clap-cargo = { version = "0.15.2", features = ["clap"] }
 dirs = "6.0.0"
-flate2 = "1.1.1"
 regex-lite = "0.1.6"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+flate2 = "1.1.1"
 reqwest = { version = "0.12.19", default-features = false, features = ["rustls-tls", "blocking", "json"] }
 tar = "0.4.44"
 zip = "4.0.0"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+html-escape = { version = "0.2.13" }
+wasm-bindgen = "0.2.100"
 
 [dev-dependencies]
 criterion = { version = "0.6.0", features = ["html_reports"] }
@@ -34,3 +52,4 @@ panic = "abort"             # reduces binary size by ~50% in combination with -Z
 split-debuginfo = "packed"  # generates a separate *.dwp/*.dSYM so the binary can get stripped
 strip = "symbols"           # See split-debuginfo - allows us to drop the size by ~65%
 incremental = true          # Improves re-compile times
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ tar = "0.4.44"
 zip = "4.0.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+ansi-to-html = "0.2.2"
 html-escape = { version = "0.2.13" }
 wasm-bindgen = "0.2.100"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,12 @@ crate-type = ["cdylib", "rlib"]
 clap = { version = "4.5.39", features = ["derive"] }
 clap-cargo = { version = "0.15.2", features = ["clap"] }
 dirs = "6.0.0"
-regex-lite = "0.1.6"
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 flate2 = "1.1.1"
+regex-lite = "0.1.6"
 reqwest = { version = "0.12.19", default-features = false, features = ["rustls-tls", "blocking", "json"] }
 tar = "0.4.44"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 zip = "4.0.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/docs/INTRODUCTION.md
+++ b/docs/INTRODUCTION.md
@@ -2,6 +2,8 @@
 
 NaijaScript na language wey you fit use learn coding, automate things, and catch fun. This book go teach you everything wey you need to know, from how we think am to how you go take use am.
 
+You wan test am quick? Try the [playground](https://naijascript-playground.pages.dev) online.
+
 ## How to Use This Book
 
 We don arrange this book so e go carry you from the idea to the action. Na so the sections take arrange:

--- a/docs/INTRODUCTION.md
+++ b/docs/INTRODUCTION.md
@@ -2,7 +2,7 @@
 
 NaijaScript na language wey you fit use learn coding, automate things, and catch fun. This book go teach you everything wey you need to know, from how we think am to how you go take use am.
 
-You wan test am quick? Try the [playground](https://naijascript-playground.pages.dev) online.
+You wan experiment quick? Try the online [playground](https://naijascript-playground.pages.dev).
 
 ## How to Use This Book
 

--- a/playground.html
+++ b/playground.html
@@ -2,27 +2,283 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Playground | The NaijaScript Interpreter</title>
+    <style>
+      :root {
+        --naija-bg: #e6f2e6;
+        --naija-text: #0a7e07;
+        --naija-accent: #008753;
+        --naija-gold: #fbc02d;
+        --naija-error: #e53935;
+        --naija-warning: #fbc02d;
+        --naija-note: #388e3c;
+        --editor-bg: #222;
+        --editor-text: #f8f8f2;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        font-family: system-ui, sans-serif;
+        background: var(--naija-bg);
+        color: var(--naija-text);
+        min-height: 100vh;
+      }
+      body {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 1.5rem 0.5rem;
+      }
+      h1 {
+        font-size: 1.5rem;
+        margin-bottom: 1rem;
+        color: var(--naija-accent);
+      }
+      .editor-container {
+        width: 100%;
+        max-width: 600px;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+      button {
+        align-self: flex-end;
+        padding: 0.5rem 1.25rem;
+        font-size: 1rem;
+        border: none;
+        border-radius: 5px;
+        background: var(--naija-accent);
+        color: #fff;
+        cursor: pointer;
+        transition: background 0.2s;
+      }
+      button:active {
+        background: var(--naija-gold);
+        color: var(--naija-text);
+      }
+      #editor {
+        resize: vertical;
+        overflow: auto;
+        min-height: 120px;
+        max-height: 60vh;
+      }
+      #output {
+        resize: vertical;
+        overflow: auto;
+        min-height: 60px;
+        max-height: 40vh;
+        width: 100%;
+        min-height: 2.5em;
+        background: var(--editor-bg);
+        color: var(--editor-text);
+        border-radius: 6px;
+        padding: 1rem;
+        margin-top: 1rem;
+        font-size: 1.05rem;
+        overflow-x: auto;
+        box-sizing: border-box;
+        word-break: break-word;
+      }
+      #help-panel {
+        display: none;
+        background: #fffbe7;
+        color: var(--naija-text);
+        border: 1px solid var(--naija-gold);
+        border-radius: 6px;
+        padding: 1rem 1.25rem;
+        margin: 1rem 0 0 0;
+        font-size: 1rem;
+        max-width: 600px;
+        width: 100%;
+        box-sizing: border-box;
+        box-shadow: 0 2px 8px #0001;
+        line-height: 1.6;
+        z-index: 2;
+      }
+      #help-panel.show {
+        display: block;
+      }
+      #help-toggle {
+        align-self: flex-end;
+        margin-bottom: 0.5rem;
+        background: var(--naija-gold);
+        color: var(--naija-accent);
+        font-weight: 500;
+        border: none;
+        border-radius: 5px;
+        padding: 0.4rem 1.1rem;
+        font-size: 1rem;
+        cursor: pointer;
+        transition: background 0.2s;
+      }
+      #help-toggle:active {
+        background: var(--naija-accent);
+        color: #fff;
+      }
+      @media (max-width: 600px) {
+        .editor-container {
+          max-width: 100vw;
+        }
+        #output {
+          font-size: 1rem;
+        }
+        #help-panel {
+          font-size: 0.98rem;
+          padding: 0.85rem 0.5rem;
+        }
+      }
+    </style>
+    <script src="https://cdn.jsdelivr.net/npm/ace-builds@1.32.3/src-min-noconflict/ace.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/ace-builds@1.32.3/src-min-noconflict/ext-language_tools.js"></script>
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css?family=Fira+Mono:400,500&display=swap"
+    />
   </head>
   <body>
     <h1>NaijaScript Playground</h1>
-    <textarea id="source" rows="10" cols="60">shout("foo\nbar")</textarea>
-    <br />
-    <button id="run">Run</button>
-    <pre id="output"></pre>
+    <div class="editor-container">
+      <button
+        id="help-toggle"
+        aria-controls="help-panel"
+        aria-expanded="false"
+        type="button"
+      >
+        Show Help
+      </button>
+      <section
+        id="help-panel"
+        tabindex="-1"
+        aria-label="NaijaScript Quick Reference"
+      >
+        <strong>NaijaScript Quick Reference</strong>
+        <ul style="margin: 0.5em 0 0.5em 1.2em; padding: 0">
+          <li><b>make</b>: Declare variable. <code>make age get 20</code></li>
+          <li><b>get</b>: Assign value. <code>age get 21</code></li>
+          <li>
+            <b>shout(...)</b>: Print to output. <code>shout("Wetin dey!")</code>
+          </li>
+          <li>
+            <b>if to say (...)</b>: Conditional.
+            <code>if to say (age pass 18) start ... end</code>
+          </li>
+          <li>
+            <b>if not so</b>: Else block. <code>if not so start ... end</code>
+          </li>
+          <li>
+            <b>jasi (...)</b>: Loop.
+            <code>jasi (count small pass 5) start ... end</code>
+          </li>
+          <li><b>start ... end</b>: Code block. <code>start ... end</code></li>
+          <li><b>Comments</b>: <code># This na comment</code></li>
+          <li><b>Numbers</b>: <code>make pi get 3.142</code></li>
+          <li><b>Strings</b>: <code>make name get "Naija"</code></li>
+          <li><b>Booleans</b>: <code>make ok get true</code></li>
+          <li>
+            <b>Operators</b>: <code>add</code> (+), <code>minus</code> (-),
+            <code>times</code> (*), <code>divide</code> (/),
+            <code>mod</code> (%)
+          </li>
+          <li>
+            <b>Comparison</b>: <code>na</code> (==), <code>pass</code> (>),
+            <code>small pass</code> (<)
+          </li>
+          <li>
+            <b>Logic</b>: <code>and</code>, <code>or</code>, <code>not</code>
+          </li>
+        </ul>
+        <div style="margin-top: 0.5em; font-size: 0.97em">
+          See
+          <a
+            href="https://xosnrdev.github.io/naijascript/LRM.html"
+            target="_blank"
+            style="color: var(--naija-accent); text-decoration: underline"
+            >Language Reference</a
+          >
+          for full details.
+        </div>
+      </section>
+      <div
+        id="editor"
+        aria-label="NaijaScript source code"
+        style="
+          min-height: 180px;
+          width: 100%;
+          font-family: 'Fira Mono', monospace;
+          border-radius: 6px;
+        "
+      ></div>
+      <button id="run">Run</button>
+      <pre id="output" aria-live="polite"></pre>
+    </div>
     <script type="module">
       import init, { run_source } from "./pkg/naijascript.js";
+      let editor;
+      function setupEditor() {
+        editor = ace.edit("editor", {
+          mode: "ace/mode/javascript",
+          theme: "ace/theme/monokai",
+          fontSize: "1.1rem",
+          wrap: true,
+          showPrintMargin: false,
+          useWorker: false,
+          highlightActiveLine: true,
+          showLineNumbers: true,
+          showGutter: true,
+          tabSize: 2,
+          value: 'shout("foo\\nbar")',
+        });
+        editor.setOptions({
+          enableBasicAutocompletion: false,
+          enableLiveAutocompletion: false,
+          enableSnippets: false,
+        });
+        editor.renderer.setScrollMargin(10, 10, 0, 0);
+        editor.container.style.fontFamily = "'Fira Mono', monospace";
+        editor.container.style.lineHeight = "1.5";
+        editor.container.style.background = "#222";
+        editor.container.style.color = "#f8f8f2";
+        editor.container.style.border = "1px solid #ccc";
+        editor.container.style.boxSizing = "border-box";
+        editor.container.style.minHeight = "180px";
+        editor.container.style.width = "100%";
+        editor.container.style.borderRadius = "6px";
+
+        new ResizeObserver(() => editor.resize()).observe(editor.container);
+      }
       async function main() {
         await init();
-        document.getElementById("run").onclick = () => {
-          const src = document.getElementById("source").value;
+        setupEditor();
+        const runBtn = document.getElementById("run");
+        const output = document.getElementById("output");
+        // Help panel toggle logic (zero-allocation, zero-latency)
+        const helpBtn = document.getElementById("help-toggle");
+        const helpPanel = document.getElementById("help-panel");
+        helpBtn.onclick = function () {
+          const show = !helpPanel.classList.contains("show");
+          helpPanel.classList.toggle("show");
+          helpBtn.setAttribute("aria-expanded", show ? "true" : "false");
+          helpBtn.textContent = show ? "Hide Help" : "Show Help";
+          if (show) helpPanel.focus();
+        };
+        function runCode() {
+          const src = editor.getValue();
           try {
             const result = run_source(src, "<playground>");
-            document.getElementById("output").innerHTML = result;
+            output.innerHTML = result;
           } catch (err) {
-            document.getElementById("output").innerHTML = err;
+            output.textContent = err;
           }
-        };
+        }
+        runBtn.onclick = runCode;
+        editor.container.addEventListener("keydown", (e) => {
+          if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+            runCode();
+            e.preventDefault();
+          }
+        });
       }
       main();
     </script>

--- a/playground.html
+++ b/playground.html
@@ -253,7 +253,6 @@
         setupEditor();
         const runBtn = document.getElementById("run");
         const output = document.getElementById("output");
-        // Help panel toggle logic (zero-allocation, zero-latency)
         const helpBtn = document.getElementById("help-toggle");
         const helpPanel = document.getElementById("help-panel");
         helpBtn.onclick = function () {
@@ -267,7 +266,7 @@
           const src = editor.getValue();
           try {
             const result = run_source(src, "<playground>");
-            output.innerHTML = result;
+            output.textContent = result;
           } catch (err) {
             output.textContent = err;
           }

--- a/playground.html
+++ b/playground.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Playground | The NaijaScript Interpreter</title>
+  </head>
+  <body>
+    <h1>NaijaScript Playground</h1>
+    <textarea id="source" rows="10" cols="60">shout("foo\nbar")</textarea>
+    <br />
+    <button id="run">Run</button>
+    <div id="output"></div>
+    <script type="module">
+      import init, { run_source } from "./pkg/naijascript.js";
+      async function main() {
+        await init();
+        document.getElementById("run").onclick = () => {
+          const src = document.getElementById("source").value;
+          try {
+            const result = run_source(src, "<playground>");
+            document.getElementById("output").innerHTML = result;
+          } catch (err) {
+            document.getElementById("output").innerHTML = err;
+          }
+        };
+      }
+      main();
+    </script>
+  </body>
+</html>

--- a/playground.html
+++ b/playground.html
@@ -9,7 +9,7 @@
     <textarea id="source" rows="10" cols="60">shout("foo\nbar")</textarea>
     <br />
     <button id="run">Run</button>
-    <div id="output"></div>
+    <pre id="output"></pre>
     <script type="module">
       import init, { run_source } from "./pkg/naijascript.js";
       async function main() {

--- a/src/bin/naija/main.rs
+++ b/src/bin/naija/main.rs
@@ -65,30 +65,30 @@ fn run_source(filename: &str, src: &str) -> ExitCode {
         return ExitCode::FAILURE;
     }
 
-    let mut analyzer = SemAnalyzer::new(
+    let mut resolver = SemAnalyzer::new(
         &parser.stmt_arena,
         &parser.expr_arena,
         &parser.cond_arena,
         &parser.block_arena,
     );
-    analyzer.analyze(root);
-    if !analyzer.errors.diagnostics.is_empty() {
-        analyzer.errors.report(src, filename);
+    resolver.analyze(root);
+    if !resolver.errors.diagnostics.is_empty() {
+        resolver.errors.report(src, filename);
         return ExitCode::FAILURE;
     }
 
-    let mut interp = Interpreter::new(
+    let mut rt = Interpreter::new(
         &parser.stmt_arena,
         &parser.expr_arena,
         &parser.cond_arena,
         &parser.block_arena,
     );
-    let diagnostics = interp.run(root);
-    if !diagnostics.diagnostics.is_empty() {
-        diagnostics.report(src, filename);
+    let err = rt.run(root);
+    if !err.diagnostics.is_empty() {
+        err.report(src, filename);
         return ExitCode::FAILURE;
     }
-    for value in &interp.output {
+    for value in &rt.output {
         println!("{value}")
     }
 

--- a/src/bin/naijaup/main.rs
+++ b/src/bin/naijaup/main.rs
@@ -1,3 +1,5 @@
+//! The official Toolchain Manager for NaijaScript
+
 use std::borrow::Cow;
 use std::fs;
 use std::fs::File;

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -96,7 +96,7 @@ impl Diagnostics {
     #[cfg(target_arch = "wasm32")]
     pub fn report_html(&self, src: &str, filename: &str) -> String {
         let ansi = self.render_ansi(src, filename);
-        ansi_to_html::convert(&ansi).unwrap_or_default()
+        ansi_to_html::convert(&ansi).unwrap()
     }
 
     // Render all diagnostics as a single ANSI string

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -8,9 +8,6 @@ pub type Span = Range<usize>;
 
 const BOLD: &str = "\x1b[1m";
 const RESET: &str = "\x1b[0m";
-const ERROR: &str = "\x1b[31m"; // red
-const WARNING: &str = "\x1b[33m"; // yellow
-const NOTE: &str = "\x1b[34m"; // blue
 
 /// Diagnostic severity levels that determine display style and output routing.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -32,18 +29,23 @@ impl Severity {
     #[inline]
     const fn color_code(self) -> &'static str {
         match self {
-            Severity::Error => ERROR,
-            Severity::Warning => WARNING,
-            Severity::Note => NOTE,
+            Severity::Error => "\x1b[31m",   // red
+            Severity::Warning => "\x1b[33m", // yellow
+            Severity::Note => "\x1b[34m",    // blue
         }
     }
 
     #[inline]
-    /// Writes a diagnostic line to the appropriate output stream.
-    fn write_to_stream(&self, s: &str) {
-        match self {
-            Severity::Error => eprintln!("{s}"),
-            _ => println!("{s}"),
+    // Writes a diagnostic line to the appropriate output stream or buffer.
+    fn write_to_stream_or_buf(&self, s: &str, buf: Option<&mut String>) {
+        if let Some(buf) = buf {
+            buf.push_str(s);
+            buf.push('\n');
+        } else {
+            match self {
+                Severity::Error => eprintln!("{s}"),
+                _ => println!("{s}"),
+            }
         }
     }
 }
@@ -86,125 +88,114 @@ impl Diagnostics {
 
     /// Report all collected diagnostics to the terminal with rich formatting.
     pub fn report(&self, src: &str, filename: &str) {
-        let gutter_width = Self::compute_gutter_width(&self.diagnostics, src);
-
-        for diag in &self.diagnostics {
-            let color = diag.severity.color_code();
-            let (line, col, line_start, line_end) = Self::line_col_from_span(src, diag.span.start);
-            let header = Self::render_header(diag.severity, diag.code, diag.message);
-            let location = Self::render_location(filename, line, col, color);
-            let src_line = &src[line_start..line_end];
-            let gutter = Self::render_gutter(line, color, gutter_width);
-            let plain_gutter = Self::render_plain_gutter(color, gutter_width);
-            let caret_count = (diag.span.end.saturating_sub(diag.span.start)).max(1);
-            let caret_line = Self::render_caret_line(col, caret_count, color, &plain_gutter);
-
-            // Partition labels based on whether they're on the same line as the main diagnostic.
-            // This affects how we render them - same-line labels appear as underlines below
-            // the source line, while cross-line labels get their own source context.
-            let (same_line_labels, cross_line_labels): (Vec<_>, Vec<_>) =
-                diag.labels.iter().partition(|label| {
-                    let (label_line, _, _, _) = Self::line_col_from_span(src, label.span.start);
-                    label_line == line
-                });
-
-            // Render same-line labels as underlines with dashes
-            let mut label_lines = Vec::new();
-            for label in same_line_labels {
-                // Convert absolute span to column position relative to line start
-                let lbl_col = label.span.start.saturating_sub(line_start) + 1;
-                let dash_count = (label.span.end.saturating_sub(label.span.start)).max(1);
-                label_lines.push(Self::render_label_line(
-                    lbl_col,
-                    dash_count,
-                    color,
-                    &label.message,
-                    &plain_gutter,
-                ));
-            }
-
-            // Handle cross-line labels by showing their complete source context
-            let mut cross_line_displays = Vec::new();
-            for label in cross_line_labels {
-                let (label_line, label_col, label_line_start, label_line_end) =
-                    Self::line_col_from_span(src, label.span.start);
-                let label_src_line = &src[label_line_start..label_line_end];
-                let label_gutter = Self::render_gutter(label_line, color, gutter_width);
-                let line_display = format!("{label_gutter}{label_src_line}");
-                let dash_count = (label.span.end.saturating_sub(label.span.start)).max(1);
-                let label_underline = Self::render_label_line(
-                    label_col,
-                    dash_count,
-                    color,
-                    &label.message,
-                    &plain_gutter,
-                );
-                cross_line_displays.push((line_display, label_underline));
-            }
-
-            // Output the complete diagnostic in the expected order:
-            // 1. Header with severity and message
-            // 2. File location pointer
-            // 3. Cross-line labels with their source context
-            // 4. Main diagnostic line with source
-            // 5. Caret line pointing to the error
-            // 6. Same-line labels with explanations
-            diag.severity.write_to_stream(&header);
-            diag.severity.write_to_stream(&location);
-            diag.severity.write_to_stream(&plain_gutter);
-            for (line_display, label_underline) in &cross_line_displays {
-                diag.severity.write_to_stream(line_display);
-                diag.severity.write_to_stream(label_underline);
-                diag.severity.write_to_stream(&plain_gutter);
-            }
-            diag.severity.write_to_stream(&format!("{gutter}{src_line}"));
-            diag.severity.write_to_stream(&caret_line);
-            for l in &label_lines {
-                diag.severity.write_to_stream(l);
-            }
-        }
+        let ansi = self.render_ansi(src, filename);
+        print!("{ansi}");
     }
 
     /// Report all collected diagnostics as HTML for the web.
     #[cfg(target_arch = "wasm32")]
     pub fn report_html(&self, src: &str, filename: &str) -> String {
+        let ansi = self.render_ansi(src, filename);
+        ansi_to_html::convert(&ansi).unwrap_or_default()
+    }
+
+    // Render all diagnostics as a single ANSI string
+    fn render_ansi(&self, src: &str, filename: &str) -> String {
+        let mut buf = String::new();
         let gutter_width = Self::compute_gutter_width(&self.diagnostics, src);
-        let mut html = String::new();
         for diag in &self.diagnostics {
-            let (line, col, line_start, line_end) = Self::line_col_from_span(src, diag.span.start);
-            let src_line = &src[line_start..line_end];
-            let caret_count = (diag.span.end.saturating_sub(diag.span.start)).max(1);
-            html.push_str(&format!(
-                "<div class='diagnostic {severity}'>\
-                  <div class='header'><span class='severity {severity}'>{severity}[{code}]</span>: <b>{msg}</b></div>\
-                  <div class='location'>--&gt; {filename}:{line}:{col}</div>\
-                  <div class='src'><span class='gutter'>{line:>gutter_width$} |</span> <span class='src-line'>{src_line}</span></div>\
-                  <div class='caret'><span class='gutter'>{gutter}</span>{caret}</div>",
-                severity=diag.severity.label(),
-                code=diag.code,
-                msg=diag.message,
-                filename=html_escape::encode_safe(filename),
-                src_line=html_escape::encode_safe(src_line),
-                gutter=" ",
-                caret="^".repeat(caret_count)
-            ));
-            for label in &diag.labels {
-                let (lbl_line, lbl_col, lbl_line_start, lbl_line_end) =
-                    Self::line_col_from_span(src, label.span.start);
-                let src_line = &src[lbl_line_start..lbl_line_end];
-                let dash_count = (label.span.end.saturating_sub(label.span.start)).max(1);
-                html.push_str(&format!(
-                    "<div class='label'><span class='gutter'>{lbl_line:>gutter_width$} |</span> <span class='src-line'>{src_line}</span></div>\
-                     <div class='label-underline'><span class='gutter'>{gutter}</span>{dashes} <b>{msg}</b></div>",
-                    src_line=html_escape::encode_safe(src_line),
-                    gutter=" ",
-                    dashes="-".repeat(dash_count),
-                    msg=label.message
-                ));
-            }
-            html.push_str("</div>");
+            Self::render_diagnostic(diag, src, filename, gutter_width, Some(&mut buf));
         }
-        html
+        buf
+    }
+
+    fn render_diagnostic(
+        diag: &Diagnostic,
+        src: &str,
+        filename: &str,
+        gutter_width: usize,
+        mut buf: Option<&mut String>,
+    ) {
+        let color = diag.severity.color_code();
+        let (line, col, line_start, line_end) = Self::line_col_from_span(src, diag.span.start);
+        let header = Self::render_header(diag.severity, diag.code, diag.message);
+        let location = Self::render_location(filename, line, col, color);
+        let src_line = &src[line_start..line_end];
+        let gutter = Self::render_gutter(line, color, gutter_width);
+        let plain_gutter = Self::render_plain_gutter(color, gutter_width);
+        let caret_count = (diag.span.end.saturating_sub(diag.span.start)).max(1);
+        let caret_line = Self::render_caret_line(col, caret_count, color, &plain_gutter);
+
+        // Partition labels based on whether they're on the same line as the main diagnostic.
+        // This affects how we render them - same-line labels appear as underlines below
+        // the source line, while cross-line labels get their own source context.
+        let (same_line_labels, cross_line_labels): (Vec<_>, Vec<_>) =
+            diag.labels.iter().partition(|label| {
+                let (label_line, _, _, _) = Self::line_col_from_span(src, label.span.start);
+                label_line == line
+            });
+
+        // Render same-line labels as underlines with dashes
+        let mut label_lines = Vec::new();
+        for label in same_line_labels {
+            // Convert absolute span to column position relative to line start
+            let lbl_col = label.span.start.saturating_sub(line_start) + 1;
+            let dash_count = (label.span.end.saturating_sub(label.span.start)).max(1);
+            label_lines.push(Self::render_label_line(
+                lbl_col,
+                dash_count,
+                color,
+                &label.message,
+                &plain_gutter,
+            ));
+        }
+
+        // Handle cross-line labels by showing their complete source context
+        let mut cross_line_displays = Vec::new();
+        for label in cross_line_labels {
+            let (label_line, label_col, label_line_start, label_line_end) =
+                Self::line_col_from_span(src, label.span.start);
+            let label_src_line = &src[label_line_start..label_line_end];
+            let label_gutter = Self::render_gutter(label_line, color, gutter_width);
+            let line_display = format!("{label_gutter}{label_src_line}");
+            let dash_count = (label.span.end.saturating_sub(label.span.start)).max(1);
+            let label_underline = Self::render_label_line(
+                label_col,
+                dash_count,
+                color,
+                &label.message,
+                &plain_gutter,
+            );
+            cross_line_displays.push((line_display, label_underline));
+        }
+
+        // Output diagnostic components in specific order to match rustc/clang format:
+        // This ordering helps developers pattern match against familiar error displays
+        // and enables tooling to parse our output using existing parsers
+        //
+        //   error[E001]: Assignment syntax no correct
+        //    --> file.ns:5:10
+        //     |
+        //   3 | make x get y
+        //     |        --- label points here
+        //     |
+        //   5 | make get 42
+        //     |      ^^^ main error caret
+        //     |      expected identifier after make
+        //
+        diag.severity.write_to_stream_or_buf(&header, buf.as_deref_mut());
+        diag.severity.write_to_stream_or_buf(&location, buf.as_deref_mut());
+        diag.severity.write_to_stream_or_buf(&plain_gutter, buf.as_deref_mut());
+        for (line_display, label_underline) in &cross_line_displays {
+            diag.severity.write_to_stream_or_buf(line_display, buf.as_deref_mut());
+            diag.severity.write_to_stream_or_buf(label_underline, buf.as_deref_mut());
+            diag.severity.write_to_stream_or_buf(&plain_gutter, buf.as_deref_mut());
+        }
+        diag.severity.write_to_stream_or_buf(&format!("{gutter}{src_line}"), buf.as_deref_mut());
+        diag.severity.write_to_stream_or_buf(&caret_line, buf.as_deref_mut());
+        for l in &label_lines {
+            diag.severity.write_to_stream_or_buf(l, buf.as_deref_mut());
+        }
     }
 
     #[inline]
@@ -225,15 +216,10 @@ impl Diagnostics {
 
     #[inline]
     fn render_plain_gutter(color: &str, width: usize) -> String {
-        format!("{BOLD}{color}{:>width$} |{RESET} ", "", width = width)
+        format!("{BOLD}{color}{:>width$} |{RESET} ", "")
     }
 
-    /// Build the caret line that points to the error location.
-    ///
-    /// This creates the "^^^" line that appears under the source code.
-    /// The tricky part is getting the column alignment right - we need to account
-    /// for the gutter width and ensure the carets line up precisely with the
-    /// problematic source text.
+    // Build the caret `^^^` line that points to the error location.
     #[inline]
     fn render_caret_line(col: usize, len: usize, color: &str, plain_gutter: &str) -> String {
         let mut caret_line = String::with_capacity(plain_gutter.len() + col + len + 8);
@@ -250,11 +236,7 @@ impl Diagnostics {
         caret_line
     }
 
-    /// Build a label underline with dashes and explanatory text.
-    ///
-    /// Labels use dashes instead of carets to distinguish them from the main
-    /// diagnostic. The horizontal alignment needs to match the source text
-    /// exactly, which requires careful column calculation.
+    // Build the label underline with dashes and explanatory text.
     #[inline]
     fn render_label_line(
         lbl_col: usize,
@@ -282,17 +264,6 @@ impl Diagnostics {
         label_line
     }
 
-    /// Convert a byte offset to line/column coordinates and line boundaries.
-    ///
-    /// This is the foundation of our source mapping system. We need four pieces
-    /// of information: the line number (1-based), column number (1-based),
-    /// and the byte offsets for the start and end of that line. The line
-    /// boundaries are crucial for extracting the source text to display.
-    ///
-    /// The algorithm works by scanning backwards from the target position to
-    /// count newlines (for line number) and find the line start. Then we scan
-    /// forward to find the line end. It's not the most efficient possible
-    /// approach, but it's simple and works well for typical error reporting.
     #[inline]
     fn line_col_from_span(src: &str, span_start: usize) -> (usize, usize, usize, usize) {
         let before = &src[..span_start];
@@ -303,9 +274,8 @@ impl Diagnostics {
         (line, col, line_start, line_end)
     }
 
-    /// Computes the gutter width needed for all diagnostics and labels.
-    ///
-    /// This ensures that the vertical bar and code are always aligned, even for large scripts.
+    // We calculate the widest line number so the gutter always lines up,
+    // no matter how many digits the line numbers have.
     #[inline]
     fn compute_gutter_width(diagnostics: &[Diagnostic], src: &str) -> usize {
         let mut max_line = 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,60 @@ pub mod diagnostics;
 pub mod resolver;
 pub mod runtime;
 pub mod syntax;
+
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+#[cfg(target_arch = "wasm32")]
+use {
+    crate::resolver::SemAnalyzer, crate::runtime::Interpreter, crate::syntax::parser::Parser,
+    crate::syntax::scanner::Lexer,
+};
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+pub fn run_source(src: &str, filename: &str) -> String {
+    use crate::runtime::Value;
+
+    let mut lexer = Lexer::new(src);
+    let tokens: Vec<_> = (&mut lexer).collect();
+    if !lexer.errors.diagnostics.is_empty() {
+        return lexer.errors.report_html(src, filename);
+    }
+
+    let mut parser = Parser::new(tokens.into_iter());
+    let (root, parse_errors) = parser.parse_program();
+    if !parse_errors.diagnostics.is_empty() {
+        return parse_errors.report_html(src, filename);
+    }
+
+    let mut resolver = SemAnalyzer::new(
+        &parser.stmt_arena,
+        &parser.expr_arena,
+        &parser.cond_arena,
+        &parser.block_arena,
+    );
+    resolver.analyze(root);
+    if !resolver.errors.diagnostics.is_empty() {
+        return resolver.errors.report_html(src, filename);
+    }
+
+    let mut rt = Interpreter::new(
+        &parser.stmt_arena,
+        &parser.expr_arena,
+        &parser.cond_arena,
+        &parser.block_arena,
+    );
+    let err = rt.run(root);
+    if !err.diagnostics.is_empty() {
+        return err.report_html(src, filename);
+    }
+
+    let v = |v: &Value| {
+        v.to_string()
+            .replace('\n', "<br />")
+            .replace("\t", "&nbsp;&nbsp;&nbsp;&nbsp;")
+            .replace("\\\"", "&quot;")
+            .replace("\\\\", "\\")
+    };
+    rt.output.iter().map(v).collect::<Vec<_>>().join("<br />")
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,6 @@ use {
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
 pub fn run_source(src: &str, filename: &str) -> String {
-    use crate::runtime::Value;
-
     let mut lexer = Lexer::new(src);
     let tokens: Vec<_> = (&mut lexer).collect();
     if !lexer.errors.diagnostics.is_empty() {
@@ -49,13 +47,5 @@ pub fn run_source(src: &str, filename: &str) -> String {
     if !err.diagnostics.is_empty() {
         return err.report_html(src, filename);
     }
-
-    let v = |v: &Value| {
-        v.to_string()
-            .replace('\n', "<br />")
-            .replace("\t", "&nbsp;&nbsp;&nbsp;&nbsp;")
-            .replace("\\\"", "&quot;")
-            .replace("\\\\", "\\")
-    };
-    rt.output.iter().map(v).collect::<Vec<_>>().join("<br />")
+    rt.output.iter().map(ToString::to_string).collect::<Vec<_>>().join("\n")
 }


### PR DESCRIPTION
## Pull Request Overview

This PR adds WebAssembly support for NaijaScript by exposing a browser entrypoint, refactoring diagnostics for HTML output, and providing a standalone web playground.

- Expose `run_source` as a `wasm_bindgen` function that returns HTML-formatted errors or execution output.
- Refactor the diagnostics module to render ANSI strings and convert them to HTML in `wasm32` builds.
- Introduce `playground.html` along with updates to documentation and `Cargo.toml` for the web target.