### PR TITLE
Fix html rendering for playground

### DIFF
--- a/playground.html
+++ b/playground.html
@@ -266,7 +266,7 @@
           const src = editor.getValue();
           try {
             const result = run_source(src, "<playground>");
-            output.textContent = result;
+            output.innerHTML = result;
           } catch (err) {
             output.textContent = err;
           }


### PR DESCRIPTION
## Pull Request Overview

This PR updates the playground’s output element to render HTML-formatted diagnostics instead of plain text.

- Changed output assignment from `textContent` to `innerHTML` to allow HTML rendering of results.