### PR TITLE
Fix handling of Unicode characters beyond ASCII

### DIFF
--- a/src/syntax/scanner.rs
+++ b/src/syntax/scanner.rs
@@ -94,7 +94,7 @@ impl<'input> Lexer<'input> {
                 return SpannedToken { token, span: start..self.pos };
             }
             // Unicode characters beyond ASCII require special handling since our lexer operates on bytes
-            if b != 0 && !b.is_ascii() {
+            if !b.is_ascii() {
                 // We need the complete Unicode character to properly skip it and report accurate spans
                 let rest = &self.src[start..];
                 if let Some(c) = rest.chars().next() {

--- a/src/syntax/scanner.rs
+++ b/src/syntax/scanner.rs
@@ -93,7 +93,33 @@ impl<'input> Lexer<'input> {
                 let token = self.scan_identifier_or_keyword(start);
                 return SpannedToken { token, span: start..self.pos };
             }
-
+            // Unicode characters beyond ASCII require special handling since our lexer operates on bytes
+            if b != 0 && !b.is_ascii() {
+                // We need the complete Unicode character to properly skip it and report accurate spans
+                let rest = &self.src[start..];
+                if let Some(c) = rest.chars().next() {
+                    let char_len = c.len_utf8();
+                    self.errors.emit(
+                        start..self.pos + char_len,
+                        Severity::Error,
+                        "lexical",
+                        LexError::UnexpectedChar.as_str(),
+                        vec![Label {
+                            span: start..self.pos + char_len,
+                            message: Cow::Borrowed(
+                                "I no sabi dis character. You fit use unicode as string",
+                            ),
+                        }],
+                    );
+                    // Skip the entire Unicode character to avoid splitting it across byte boundaries
+                    self.pos += char_len;
+                    continue;
+                } else {
+                    // Invalid UTF-8 sequence detected, so we advance by one byte to prevent infinite loops
+                    self.pos += 1;
+                    continue;
+                }
+            }
             if b != 0
                 && let Some(token) = self.scan_unexpected(start)
             {

--- a/tests/scanner.rs
+++ b/tests/scanner.rs
@@ -271,11 +271,11 @@ fn test_scan_trailing_comment() {
 
 #[test]
 fn test_utf8_boundary_panic() {
-    let src = "shout(😆)";
+    let src = "😆";
     let mut lexer = Lexer::new(src);
     let _ = lexer.next_token();
-    let _ = lexer.next_token();
-    let _ = lexer.next_token();
     let errors = lexer.errors;
+    let label = &errors.diagnostics[0].labels[0];
+    assert_eq!(label.span, 0..4);
     assert!(errors.diagnostics.iter().any(|e| e.message == LexError::UnexpectedChar.as_str()));
 }

--- a/tests/scanner.rs
+++ b/tests/scanner.rs
@@ -268,3 +268,14 @@ fn test_scan_trailing_comment() {
         Token::EOF
     );
 }
+
+#[test]
+fn test_utf8_boundary_panic() {
+    let src = "shout(😆)";
+    let mut lexer = Lexer::new(src);
+    let _ = lexer.next_token();
+    let _ = lexer.next_token();
+    let _ = lexer.next_token();
+    let errors = lexer.errors;
+    assert!(errors.diagnostics.iter().any(|e| e.message == LexError::UnexpectedChar.as_str()));
+}


### PR DESCRIPTION
## Pull Request Overview

This PR adds special handling for multi-byte Unicode characters in the lexer to prevent incorrect span reporting or infinite loops on invalid UTF-8, and verifies this behavior with a new test.

- Enhance `Lexer` to detect non-ASCII bytes, emit an `UnexpectedChar` error with proper span, and skip full Unicode characters.
- Add `test_utf8_boundary_panic` to ensure the lexer reports an error for a Unicode character input.