### PR TITLE
Add error handling for reserved keywords in parser

### DIFF
--- a/src/syntax/token.rs
+++ b/src/syntax/token.rs
@@ -57,6 +57,35 @@ pub enum Token<'input> {
     EOF, // End of file
 }
 
+impl<'input> std::fmt::Display for Token<'input> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Token::Make => write!(f, "make"),
+            Token::Get => write!(f, "get"),
+            Token::Add => write!(f, "add"),
+            Token::Minus => write!(f, "minus"),
+            Token::Times => write!(f, "times"),
+            Token::Divide => write!(f, "divide"),
+            Token::Mod => write!(f, "mod"),
+            Token::And => write!(f, "and"),
+            Token::Or => write!(f, "or"),
+            Token::Not => write!(f, "not"),
+            Token::Shout => write!(f, "shout"),
+            Token::Jasi => write!(f, "jasi"),
+            Token::Start => write!(f, "start"),
+            Token::End => write!(f, "end"),
+            Token::Na => write!(f, "na"),
+            Token::Pass => write!(f, "pass"),
+            Token::SmallPass => write!(f, "small pass"),
+            Token::IfToSay => write!(f, "if to say"),
+            Token::IfNotSo => write!(f, "if not so"),
+            Token::True => write!(f, "true"),
+            Token::False => write!(f, "false"),
+            _ => write!(f, "{self:?}"),
+        }
+    }
+}
+
 impl<'input> Token<'input> {
     pub fn suggest_keyword(ident: &str) -> Option<&'static str> {
         Self::all_keywords()
@@ -64,6 +93,33 @@ impl<'input> Token<'input> {
             .find(|&&kw| Self::is_single_edit(ident, kw))
             .copied()
             .map(|v| v as _)
+    }
+
+    pub fn is_reserved_keyword(&self) -> bool {
+        matches!(
+            self,
+            Token::Make
+                | Token::Get
+                | Token::Add
+                | Token::Minus
+                | Token::Times
+                | Token::Divide
+                | Token::Mod
+                | Token::And
+                | Token::Or
+                | Token::Not
+                | Token::Shout
+                | Token::Jasi
+                | Token::Start
+                | Token::End
+                | Token::Na
+                | Token::Pass
+                | Token::SmallPass
+                | Token::IfToSay
+                | Token::IfNotSo
+                | Token::True
+                | Token::False
+        )
     }
 
     // Returns a static list of all reserved keywords in NaijaScript.

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -62,7 +62,7 @@ fn test_parse_loop_statement() {
 #[test]
 fn test_parse_missing_identifier_after_make() {
     let src = "make get 5";
-    assert_parse!(src, SyntaxError::ExpectedIdentifierAfterMake);
+    assert_parse!(src, SyntaxError::ReservedKeywordAsIdentifier);
 }
 
 #[test]
@@ -135,4 +135,10 @@ fn test_parse_boolean_literals() {
 fn test_parse_boolean_comparison() {
     let src = "if to say (true na false) start end";
     assert_parse!(src);
+}
+
+#[test]
+fn test_reserved_keyword_as_identifier() {
+    let src = "make shout get 5";
+    assert_parse!(src, SyntaxError::ReservedKeywordAsIdentifier);
 }


### PR DESCRIPTION
## Pull Request Overview

Adds explicit error handling when a user attempts to use a language-reserved keyword as an identifier in `make` statements.

- Introduces a new `SyntaxError::ReservedKeywordAsIdentifier` variant and maps it to a user-friendly message.
- Extends the parser’s `parse_assignment` to detect reserved keywords and emit the new error.
- Implements `Display` and an `is_reserved_keyword` helper on `Token`, and updates tests to cover the new behavior.