### PR TITLE
Handle builtins as reserved keyword

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,6 @@ split-debuginfo = "packed"  # generates a separate *.dwp/*.dSYM so the binary ca
 strip = "symbols"           # See split-debuginfo - allows us to drop the size by ~65%
 incremental = true          # Improves re-compile times
 
+[profile.bench]
+inherits = "release"
+panic = "unwind"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,11 +5,9 @@ pub mod runtime;
 pub mod syntax;
 
 #[cfg(target_arch = "wasm32")]
-use wasm_bindgen::prelude::*;
-#[cfg(target_arch = "wasm32")]
 use {
     crate::resolver::SemAnalyzer, crate::runtime::Interpreter, crate::syntax::parser::Parser,
-    crate::syntax::scanner::Lexer, crate::syntax::token::SpannedToken,
+    crate::syntax::scanner::Lexer, crate::syntax::token::SpannedToken, wasm_bindgen::prelude::*,
 };
 
 #[cfg(target_arch = "wasm32")]

--- a/tests/resolver.rs
+++ b/tests/resolver.rs
@@ -189,3 +189,18 @@ fn test_duplicate_function_in_same_block() {
         SemanticError::DuplicateIdentifier
     );
 }
+
+#[test]
+fn test_reserved_keyword_as_variable_name() {
+    assert_resolve!("make shout get 1", SemanticError::ReservedKeywordAsIdentifier);
+}
+
+#[test]
+fn test_reserved_keyword_as_function_name() {
+    assert_resolve!("do shout() start end", SemanticError::ReservedKeywordAsIdentifier);
+}
+
+#[test]
+fn test_reserved_keyword_as_parameter_name() {
+    assert_resolve!("do foo(shout) start end", SemanticError::ReservedKeywordAsIdentifier);
+}


### PR DESCRIPTION
This pull request introduces a new semantic check to prevent the use of builtins(reserved keywords) as variable names, function names, or parameter names, along with associated tests and minor configuration updates. 