### PR TITLE
Add support for unary minus operator

### DIFF
--- a/docs/LRM.md
+++ b/docs/LRM.md
@@ -50,12 +50,13 @@ Literals na the fixed values wey you dey write directly for your code.
 - **Arithmetic**: `add` (+), `minus` (-), `times` (\*), `divide` (/), `mod` (%)
 - **Comparison**: `na` (==), `pass` (>), `small pass` (<)
 - **Logical**: `and` (logical AND), `or` (logical OR), `not` (logical NOT)
+- **Unary**: `not` (logical negation), `minus` (arithmetic negation)
 
 **Operator Precedence (from highest to lowest):**
 
-1. `not`
+1. `not`, `minus` (unary operators)
 2. `times`, `divide`, `mod`
-3. `add`, `minus`
+3. `add`, `minus` (binary operators)
 4. `na`, `pass`, `small pass`
 5. `and`
 6. `or`

--- a/docs/grammar.bnf
+++ b/docs/grammar.bnf
@@ -87,6 +87,7 @@
 <arith_expr> ::= <term> (("add" | "minus") <term>)*
 <term> ::= <factor> (("times" | "divide" | "mod") <factor>)*
 <factor> ::= "not" <factor>
+           | "minus" <factor>
            | "(" <expression> ")"
            | <function_call>
            | <variable>

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -401,6 +401,15 @@ impl<'src> Runtime<'src> {
                     ),
                 }
             }
+            Expr::UnaryMinus { expr, .. } => {
+                let v = self.eval_expr(*expr)?;
+                match v {
+                    Value::Number(n) => Ok(Value::Number(-n)),
+                    _ => unreachable!(
+                        "Semantic analysis should guarantee only valid numeric expressions"
+                    ),
+                }
+            }
             Expr::Call { callee, args, span } => {
                 // Function calls, semantic analysis guarantees function exists
                 self.eval_function_call(*callee, *args, span)

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -256,3 +256,51 @@ fn test_parse_return_with_value() {
     let src = "return 42";
     assert_parse!(src);
 }
+
+#[test]
+fn test_parse_unary_minus() {
+    let src = "make x get minus 5";
+    assert_parse!(src);
+}
+
+#[test]
+fn test_parse_unary_minus_in_parentheses() {
+    let src = "make x get (minus 5)";
+    assert_parse!(src);
+}
+
+#[test]
+fn test_parse_unary_minus_mixed_expression() {
+    let src = "make x get 3 add minus 2";
+    assert_parse!(src);
+}
+
+#[test]
+fn test_parse_unary_minus_precedence() {
+    let src = "make x get minus 3 times 4"; // Should parse as (-3) * 4
+    assert_parse!(src);
+}
+
+#[test]
+fn test_parse_double_unary_minus() {
+    let src = "make x get minus minus 5"; // Should parse as -(-5)
+    assert_parse!(src);
+}
+
+#[test]
+fn test_parse_unary_minus_with_variable() {
+    let src = "make y get 3 make x get minus y";
+    assert_parse!(src);
+}
+
+#[test]
+fn test_parse_unary_minus_in_function_call() {
+    let src = "shout(minus 5)";
+    assert_parse!(src);
+}
+
+#[test]
+fn test_parse_mixed_binary_and_unary_minus() {
+    let src = "make x get 5 minus minus 3"; // Should parse as 5 - (-3)
+    assert_parse!(src);
+}

--- a/tests/resolver.rs
+++ b/tests/resolver.rs
@@ -234,3 +234,18 @@ fn test_inconsistent_return_type() {
         SemanticError::TypeMismatch
     );
 }
+
+#[test]
+fn test_unary_minus_with_string() {
+    assert_resolve!(r#"make x get minus "hello""#, SemanticError::TypeMismatch);
+}
+
+#[test]
+fn test_unary_minus_with_boolean() {
+    assert_resolve!(r#"make x get minus true"#, SemanticError::TypeMismatch);
+}
+
+#[test]
+fn test_unary_minus_with_undeclared_variable() {
+    assert_resolve!(r#"make x get minus y"#, SemanticError::UndeclaredIdentifier);
+}

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -369,3 +369,47 @@ fn do_dynamic_concatenation() {
         output: vec![Value::Str(Cow::Owned("one2".to_string()))]
     );
 }
+
+#[test]
+fn unary_minus() {
+    assert_runtime!("shout(minus 5)", output: vec![Value::Number(-5.0)]);
+}
+
+#[test]
+fn unary_minus_in_parentheses() {
+    assert_runtime!("shout((minus 5))", output: vec![Value::Number(-5.0)]);
+}
+
+#[test]
+fn unary_minus_with_variable() {
+    assert_runtime!("make x get 3 shout(minus x)", output: vec![Value::Number(-3.0)]);
+}
+
+#[test]
+fn unary_minus_precedence() {
+    // Should parse as (-3) * 4 = -12
+    assert_runtime!("shout(minus 3 times 4)", output: vec![Value::Number(-12.0)]);
+}
+
+#[test]
+fn double_unary_minus() {
+    // Should parse as -(-5) = 5
+    assert_runtime!("shout(minus minus 5)", output: vec![Value::Number(5.0)]);
+}
+
+#[test]
+fn unary_minus_in_arithmetic() {
+    // Should parse as 3 + (-2) = 1
+    assert_runtime!("shout(3 add minus 2)", output: vec![Value::Number(1.0)]);
+}
+
+#[test]
+fn mixed_binary_and_unary_minus() {
+    // Should parse as 5 - (-3) = 8
+    assert_runtime!("shout(5 minus minus 3)", output: vec![Value::Number(8.0)]);
+}
+
+#[test]
+fn unary_minus_with_decimal() {
+    assert_runtime!("shout(minus 3.12)", output: vec![Value::Number(-3.12)]);
+}


### PR DESCRIPTION
Introduce the unary minus operator for arithmetic negation making e.g `shout(minus -5)` and `make x get minus 5` a valid expression, respecting operator precedence as needed.