### PR TITLE
Fix UTF-8 column positioning and width calculation

### DIFF
--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -835,7 +835,7 @@ impl<'src> Resolver<'src> {
                                 SemanticError::UndeclaredIdentifier.as_str(),
                                 vec![Label {
                                     span: span.clone(),
-                                    message: Cow::Borrowed("You never define dis function before"),
+                                    message: Cow::Borrowed("Dis function no dey scope"),
                                 }],
                             );
                         }


### PR DESCRIPTION
The diagnostics system was using byte positions instead of character positions for UTF-8 text, causing incorrect column reporting and visual misalignment for non-ASCII characters.

Before

```naijascript
error[lexical]: Unexpected character
 --> <playground>:1:22
  | 
1 | make x get "foóbár";
  |                      ^
  |                      - I no sabi dis character
  ```
  
After
  
```naijascript
error[lexical]: Unexpected character
 --> <playground>:1:20
  | 
1 | make x get "foóbár";
  |                    ^
  |                      - I no sabi dis character
```