### PR TITLE
Fix read_line to exclude new line character

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -103,7 +103,7 @@ impl Stdin for UnixStdin {
             let hay = unsafe { slice::from_raw_parts(base, len) };
             let pos = memchr(b'\n', hay, len - n);
             if pos < len {
-                len = pos + 1;
+                len = pos;
                 break;
             }
         }

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -321,7 +321,7 @@ fn read_line_pipe<'arena>(arena: &'arena Arena) -> Result<ArenaString<'arena>, i
         let hay = unsafe { slice::from_raw_parts(base, total) };
         let pos = memchr(b'\n', hay, total - n);
         if pos < total {
-            total = pos + 1;
+            total = pos;
             break;
         }
     }


### PR DESCRIPTION
The `read_line` function was including the newline character (`\n`) in the returned string, which caused two issues:

1. String interpolation breaking: When the string with a newline was used in string interpolation like "Hello {name}!", it would print as:

```sh
Hello john
!
```
instead of "Hello john!"

2. Unexpected behavior: It return strings with trailing newlines that needed to be trimmed.