### PR TITLE
Fix registry access rights for setting PATH on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,14 @@ wasm-bindgen = "0.2.100"
 libc = "0.2.175"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.60.2", features = ["Win32_System_Memory", "Win32_System_Registry", "Win32_System_Console", "Win32_Storage_FileSystem", "Win32_System_IO"] }
+windows-sys = { version = "0.60.2", features = [
+	"Win32_System_Memory",
+	"Win32_System_Registry",
+	"Win32_System_Console",
+	"Win32_Storage_FileSystem",
+	"Win32_System_IO",
+	"Win32_UI_WindowsAndMessaging",
+] }
 
 [dev-dependencies]
 criterion = { version = "0.6.0", features = ["html_reports"] }


### PR DESCRIPTION
This pull request updates how the Windows registry is modified for the `PATH` environment variable in `src/sys/windows.rs`. The main change is that the code now properly handles removing the `PATH` value when an empty string is provided, and uses more appropriate registry access rights.

**Registry access and value modification:**

* Changed registry access from `KEY_WRITE` to `KEY_SET_VALUE` for opening the registry key, which is the correct permission for setting values.
* Added logic to remove the `PATH` value from the registry using `RegDeleteValueW` when an empty string is provided, ensuring that the value is deleted rather than set to empty.
* Updated the code to set the value as `REG_SZ` only when the new path is not empty, maintaining correct registry semantics.