### PR TITLE
Add support for array literal values

### DIFF
--- a/docs/LRM.md
+++ b/docs/LRM.md
@@ -46,6 +46,8 @@ Literals na the fixed values wey you dey write directly for your code.
 - **Booleans**: Truth values wey be `true` and `false`.
   - `true` - mean say e correct or e happen.
   - `false` - mean say e no correct or e no happen.
+- **Arrays**: Ordered collection of values inside square brackets.
+  - Example: `[1, 2, 3]`, `["naija", "4ever",]`, `[make_it(), other_value]`
 
 ### 2.4. Operators
 
@@ -65,7 +67,8 @@ Literals na the fixed values wey you dey write directly for your code.
 
 ### 2.5. Punctuation
 
-- `(` and `)`: Used for grouping expressions and in `shout`, `if to say`, and `jasi` statements.
+- `(` and `)`: For grouping expressions. 
+- `[` and `]`: For array literals.
 
 ### 2.6. Whitespace and Comments
 
@@ -83,11 +86,12 @@ This section dey cover the rules wey dey checked before your code run.
 
 ### 4.1. Type System
 
-NaijaScript get three main data types:
+NaijaScript get four main data types:
 
 - **Number**: Represents numeric values (e.g., `10`, `99.9`). All numbers na floating-point numbers.
 - **String**: Represents text (e.g., `"Naija"`).
 - **Boolean**: Represents truth values wey fit be `true` or `false`.
+- **Array**: Represents ordered collection of values.
 
 Type inference dey automatic. You no need to declare the type of a variable.
 
@@ -127,6 +131,8 @@ This section dey explain wetin each part of the language dey do when e dey run.
 **Logical**: Expressions wey use `and`, `or`, and `not` dey join or change boolean values. Dem only work if the values na `true` or `false`. If you try use dem with number or string, e go cause a semantic error.
 
 **Function Call**: You fit call a function by writing its name followed by arguments in parentheses. The function go run and return a value wey you fit use for further expressions.
+
+**Array Literals**: Expressions inside square brackets. NaijaScript go evaluate each element from left to right before arranging dem inside the array.
 
 ## 6. Built-in Functions
 

--- a/docs/grammar.ebnf
+++ b/docs/grammar.ebnf
@@ -61,7 +61,10 @@ factor          = "not" factor
                 | variable
                 | number
                 | string
-                | boolean ;
+                | boolean
+                | array ;
+
+array           = "[" [ expression { "," expression } [ "," ] ] "]" ;
 
 boolean         = "true" | "false" ;
 

--- a/examples/array.ns
+++ b/examples/array.ns
@@ -1,0 +1,3 @@
+make value get [1, 2, 3, "foo", "baz", true, false]
+shout(value)
+shout(typeof(value))

--- a/src/syntax/scanner.rs
+++ b/src/syntax/scanner.rs
@@ -356,6 +356,14 @@ impl<'arena, 'input> Lexer<'arena, 'input> {
                 self.pos += 1;
                 Some(Token::RParen)
             }
+            b'[' => {
+                self.pos += 1;
+                Some(Token::LBracket)
+            }
+            b']' => {
+                self.pos += 1;
+                Some(Token::RBracket)
+            }
             b',' => {
                 self.pos += 1;
                 Some(Token::Comma)

--- a/src/syntax/token.rs
+++ b/src/syntax/token.rs
@@ -58,9 +58,11 @@ pub enum Token<'arena, 'input> {
     False, // "false" - falsy
 
     // Punctuation
-    LParen, // "("
-    RParen, // ")"
-    Comma,  // ","
+    LParen,   // "("
+    RParen,   // ")"
+    LBracket, // "["
+    RBracket, // "]"
+    Comma,    // ","
 
     // Special tokens
     #[default]
@@ -90,6 +92,8 @@ impl<'arena, 'input> std::fmt::Display for Token<'arena, 'input> {
             Token::IfNotSo => write!(f, "if not so"),
             Token::True => write!(f, "true"),
             Token::False => write!(f, "false"),
+            Token::LBracket => write!(f, "["),
+            Token::RBracket => write!(f, "]"),
             _ => write!(f, "{self:?}"),
         }
     }

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -81,6 +81,30 @@ fn test_parse_parenthesized_expression() {
 }
 
 #[test]
+fn test_parse_array_literal_empty() {
+    let src = "make nums get []";
+    assert_parse!(src);
+}
+
+#[test]
+fn test_parse_array_literal_trailing_comma() {
+    let src = "make nums get [1, 2, 3,]";
+    assert_parse!(src);
+}
+
+#[test]
+fn test_parse_array_literal_nested() {
+    let src = "make grid get [[1], [2, 3]]";
+    assert_parse!(src);
+}
+
+#[test]
+fn test_parse_array_literal_error_missing_bracket() {
+    let src = "make nums get [1, 2";
+    assert_parse!(src, SyntaxError::ExpectedRBracket);
+}
+
+#[test]
 fn test_parse_condition_na() {
     let src = "if to say (x na 1) start end";
     assert_parse!(src);

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -1,3 +1,5 @@
+#![feature(allocator_api)]
+
 use naijascript::KIBI;
 use naijascript::arena::{Arena, ArenaCow, ArenaString};
 use naijascript::diagnostics::AsStr;
@@ -199,6 +201,21 @@ fn logical_not_operator() {
 fn logical_operator_precedence() {
     assert_runtime!("shout(true or false and false)", output: vec![Value::Bool(true)]);
     assert_runtime!("shout((true or false) and false)", output: vec![Value::Bool(false)]);
+}
+
+#[test]
+fn array_output() {
+    let arena = Arena::new(4 * KIBI).unwrap();
+    let mut value = Vec::with_capacity_in(3, &arena);
+    value.extend_from_slice(&[Value::Number(1.0), Value::Number(2.0), Value::Number(3.0)]);
+    assert_runtime!("make nums get [1, 2, 3] shout(nums)", output: vec![Value::Array(value)]);
+}
+
+#[test]
+fn empty_array() {
+    let arena = Arena::new(4 * KIBI).unwrap();
+    let value: Vec<Value, &Arena> = Vec::with_capacity_in(0, &arena);
+    assert_runtime!("make empty get [] shout(empty)", output: vec![Value::Array(value)]);
 }
 
 #[test]

--- a/tests/scanner.rs
+++ b/tests/scanner.rs
@@ -65,6 +65,12 @@ fn test_scan_punctuation() {
     assert_tokens!(src, &[Token::LParen, Token::RParen]);
 }
 
+#[test]
+fn test_scan_brackets() {
+    let src = "[ ]";
+    assert_tokens!(src, &[Token::LBracket, Token::RBracket]);
+}
+
 //------------------------------------------------------------------------
 // IDENTIFIERS
 //------------------------------------------------------------------------


### PR DESCRIPTION
## Pull Request Overview

This PR adds support for array literal values to NaijaScript, enabling users to create arrays using square bracket notation. It implements array literals as a first-class language feature with proper parsing, runtime evaluation, and type checking.

Key changes:
- Introduces new bracket tokens (`[`, `]`) to the lexer and parser
- Adds array expression support with parsing for empty arrays, trailing commas, and nested arrays
- Implements runtime evaluation and display formatting for array values
- Updates type system to handle array operations and prevent invalid operations