### PR TITLE
Add first-class bounded process execution for scripting workflows

### DIFF
--- a/docs/BUILTIN_FUNCTIONS.md
+++ b/docs/BUILTIN_FUNCTIONS.md
@@ -48,3 +48,21 @@ make x get 42
 make s get to_string(x)
 shout(s)
 ```
+
+## Workflow
+
+### command(program)
+
+Creates a `process_command` builder for direct child-process execution. See
+[Process Execution](PROCESS_EXECUTION.md) for the full method set and runtime
+behavior.
+
+Example:
+
+```naijascript
+make cmd get command("git")
+cmd.arg("status")
+cmd.stdout_capture()
+make res get cmd.run()
+shout(res.stdout())
+```

--- a/docs/PROCESS_EXECUTION.md
+++ b/docs/PROCESS_EXECUTION.md
@@ -1,0 +1,106 @@
+# Process Execution
+
+NaijaScript can run native child processes with `command(program)`.
+
+This feature is for scripting and workflow automation. It is:
+
+- direct execution, not shell execution
+- synchronous
+- available on native targets
+- unsupported on wasm
+
+## Quick start
+
+```naijascript
+make cmd get command("git")
+cmd.arg("status")
+cmd.stdout_capture()
+make res get cmd.run()
+
+if to say (res.success()) start
+    shout(res.stdout())
+end
+```
+
+`command(program)` returns a `process_command` builder. `run()` returns a
+`process_result`.
+
+## Builder methods
+
+`process_command` supports:
+
+- `arg(value)`
+- `cwd(path)`
+- `env(key, value)`
+- `stdin_text(text)`
+- `stdin_inherit()`
+- `stdin_null()`
+- `stdout_capture()`
+- `stdout_inherit()`
+- `stdout_null()`
+- `stderr_capture()`
+- `stderr_inherit()`
+- `stderr_null()`
+- `timeout_ms(value)`
+- `run()`
+
+Mutating builder methods update the command in place and return `null`.
+
+## Result methods
+
+`process_result` supports:
+
+- `success()`
+- `exit_code()`
+- `stdout()`
+- `stderr()`
+
+Non-zero exit status is normal result data. It is not an interpreter error.
+
+## Common patterns
+
+### Capture output
+
+```naijascript
+make cmd get command("git")
+cmd.arg("rev-parse")
+cmd.arg("--short")
+cmd.arg("HEAD")
+cmd.stdout_capture()
+
+make res get cmd.run()
+if to say (res.success()) start
+    shout("commit: {res.stdout()}")
+end
+```
+
+### Set working directory and environment
+
+```naijascript
+make cmd get command("git")
+cmd.arg("status")
+cmd.cwd("/tmp/repo")
+cmd.env("GIT_PAGER", "cat")
+cmd.stdout_capture()
+
+make res get cmd.run()
+shout(res.stdout())
+```
+
+### Feed stdin
+
+```naijascript
+make cmd get command("sort")
+cmd.stdin_text("b\na\n")
+cmd.stdout_capture()
+
+make res get cmd.run()
+shout(res.stdout())
+```
+
+## Notes
+
+- There is no shell interpolation.
+- Argument boundaries are preserved exactly.
+- Captured stdout and stderr are UTF-8 text.
+- Oversized captured output fails with a runtime error instead of truncating.

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,7 +37,8 @@ Read more in [this article](https://hackmd.io/sIhWJ4QeSAGiaE3D-xiieg).
 
 While NaijaScript aims to be a practical scripting language, it currently has some limitations:
 
-- No package management or extensive standard library yet
+- Native process execution is available, but the standard library is still small
+- No package management yet
 - Designed for educational and scripting use cases, not large-scale applications
 - Lacks IDE support and advanced tooling
 
@@ -45,5 +46,6 @@ While NaijaScript aims to be a practical scripting language, it currently has so
 
 - How to install NaijaScript and run the interpreter
 - The language syntax and core semantics
+- How to automate external tools with native process execution
 
 Ready to begin? Let's start with [installation](INSTALLATION.md).

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -25,3 +25,4 @@
 
 - [Defining Functions](FUNCTIONS.md)
 - [Built-in Functions](BUILTIN_FUNCTIONS.md)
+- [Process Execution](PROCESS_EXECUTION.md)

--- a/src/analysis/effects.rs
+++ b/src/analysis/effects.rs
@@ -1,6 +1,8 @@
 //! Effect and trap classification for analysis passes.
 
-use crate::builtins::{ArrayBuiltin, GlobalBuiltin, MemberBuiltin};
+use crate::builtins::{
+    ArrayBuiltin, GlobalBuiltin, MemberBuiltin, ProcessCommandBuiltin, ProcessResultBuiltin,
+};
 
 /// Conservative effect class for an expression or statement.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -26,7 +28,9 @@ impl ExprClass {
 #[must_use]
 pub const fn global_builtin_class(builtin: GlobalBuiltin) -> ExprClass {
     match builtin {
-        GlobalBuiltin::TypeOf | GlobalBuiltin::ToString => ExprClass::PureNoTrap,
+        GlobalBuiltin::TypeOf | GlobalBuiltin::ToString | GlobalBuiltin::Command => {
+            ExprClass::PureNoTrap
+        }
         GlobalBuiltin::ReadLine | GlobalBuiltin::Shout => ExprClass::Impure,
     }
 }
@@ -37,6 +41,12 @@ pub const fn member_builtin_class(builtin: MemberBuiltin) -> ExprClass {
     match builtin {
         MemberBuiltin::Array(array_builtin) => array_builtin_class(array_builtin),
         MemberBuiltin::String(..) | MemberBuiltin::Number(..) => ExprClass::PureNoTrap,
+        MemberBuiltin::ProcessCommand(command_builtin) => {
+            process_command_builtin_class(command_builtin)
+        }
+        MemberBuiltin::ProcessResult(result_builtin) => {
+            process_result_builtin_class(result_builtin)
+        }
     }
 }
 
@@ -44,5 +54,33 @@ const fn array_builtin_class(builtin: ArrayBuiltin) -> ExprClass {
     match builtin {
         ArrayBuiltin::Len | ArrayBuiltin::Join => ExprClass::PureNoTrap,
         ArrayBuiltin::Push | ArrayBuiltin::Pop | ArrayBuiltin::Reverse => ExprClass::Impure,
+    }
+}
+
+const fn process_command_builtin_class(builtin: ProcessCommandBuiltin) -> ExprClass {
+    match builtin {
+        ProcessCommandBuiltin::Run
+        | ProcessCommandBuiltin::Arg
+        | ProcessCommandBuiltin::Cwd
+        | ProcessCommandBuiltin::Env
+        | ProcessCommandBuiltin::StdinText
+        | ProcessCommandBuiltin::StdinInherit
+        | ProcessCommandBuiltin::StdinNull
+        | ProcessCommandBuiltin::StdoutCapture
+        | ProcessCommandBuiltin::StdoutInherit
+        | ProcessCommandBuiltin::StdoutNull
+        | ProcessCommandBuiltin::StderrCapture
+        | ProcessCommandBuiltin::StderrInherit
+        | ProcessCommandBuiltin::StderrNull
+        | ProcessCommandBuiltin::TimeoutMs => ExprClass::Impure,
+    }
+}
+
+const fn process_result_builtin_class(builtin: ProcessResultBuiltin) -> ExprClass {
+    match builtin {
+        ProcessResultBuiltin::Success
+        | ProcessResultBuiltin::ExitCode
+        | ProcessResultBuiltin::Stdout
+        | ProcessResultBuiltin::Stderr => ExprClass::PureNoTrap,
     }
 }

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -1,5 +1,6 @@
 mod array;
 mod number;
+mod process;
 mod replace;
 mod string;
 mod tw;
@@ -8,6 +9,7 @@ use std::{fmt, io};
 
 pub use array::*;
 pub use number::*;
+pub use process::*;
 pub use replace::*;
 pub use string::*;
 pub use tw::*;
@@ -15,6 +17,7 @@ pub use tw::*;
 use crate::arena::{Arena, ArenaString};
 use crate::arena_format;
 use crate::helpers::ValueType;
+use crate::process::HostValue;
 use crate::runtime::Value;
 use crate::sys::{self, Stdin};
 
@@ -41,6 +44,8 @@ pub enum GlobalBuiltin {
     ReadLine,
     /// Convert a value to a string
     ToString,
+    /// Construct a process command builder
+    Command,
 }
 
 impl Builtin for GlobalBuiltin {
@@ -49,7 +54,8 @@ impl Builtin for GlobalBuiltin {
             GlobalBuiltin::Shout
             | GlobalBuiltin::TypeOf
             | GlobalBuiltin::ReadLine
-            | GlobalBuiltin::ToString => 1,
+            | GlobalBuiltin::ToString
+            | GlobalBuiltin::Command => 1,
         }
     }
 
@@ -59,6 +65,7 @@ impl Builtin for GlobalBuiltin {
             GlobalBuiltin::TypeOf | GlobalBuiltin::ReadLine | GlobalBuiltin::ToString => {
                 ValueType::String
             }
+            GlobalBuiltin::Command => ValueType::ProcessCommand,
         }
     }
 
@@ -68,6 +75,7 @@ impl Builtin for GlobalBuiltin {
             "typeof" => Some(GlobalBuiltin::TypeOf),
             "read_line" => Some(GlobalBuiltin::ReadLine),
             "to_string" => Some(GlobalBuiltin::ToString),
+            "command" => Some(GlobalBuiltin::Command),
             _ => None,
         }
     }
@@ -95,6 +103,10 @@ impl GlobalBuiltin {
             Value::Str(..) => "string",
             Value::Bool(..) => "boolean",
             Value::Array(..) => "array",
+            Value::Host(host) => match host.get() {
+                HostValue::ProcessCommand(..) => "process_command",
+                HostValue::ProcessResult(..) => "process_result",
+            },
             Value::Null => "null",
         }
     }
@@ -114,6 +126,8 @@ pub enum MemberBuiltin {
     String(StringBuiltin),
     Array(ArrayBuiltin),
     Number(NumberBuiltin),
+    ProcessCommand(ProcessCommandBuiltin),
+    ProcessResult(ProcessResultBuiltin),
 }
 
 impl Builtin for MemberBuiltin {
@@ -122,6 +136,8 @@ impl Builtin for MemberBuiltin {
             MemberBuiltin::String(b) => b.arity(),
             MemberBuiltin::Array(b) => b.arity(),
             MemberBuiltin::Number(b) => b.arity(),
+            MemberBuiltin::ProcessCommand(b) => b.arity(),
+            MemberBuiltin::ProcessResult(b) => b.arity(),
         }
     }
 
@@ -130,6 +146,8 @@ impl Builtin for MemberBuiltin {
             MemberBuiltin::String(b) => b.return_type(),
             MemberBuiltin::Array(b) => b.return_type(),
             MemberBuiltin::Number(b) => b.return_type(),
+            MemberBuiltin::ProcessCommand(b) => b.return_type(),
+            MemberBuiltin::ProcessResult(b) => b.return_type(),
         }
     }
 
@@ -138,6 +156,8 @@ impl Builtin for MemberBuiltin {
             .map(MemberBuiltin::String)
             .or_else(|| ArrayBuiltin::from_name(name).map(MemberBuiltin::Array))
             .or_else(|| NumberBuiltin::from_name(name).map(MemberBuiltin::Number))
+            .or_else(|| ProcessCommandBuiltin::from_name(name).map(MemberBuiltin::ProcessCommand))
+            .or_else(|| ProcessResultBuiltin::from_name(name).map(MemberBuiltin::ProcessResult))
     }
 
     fn requires_mut_receiver(&self) -> bool {
@@ -145,6 +165,8 @@ impl Builtin for MemberBuiltin {
             MemberBuiltin::String(b) => b.requires_mut_receiver(),
             MemberBuiltin::Array(b) => b.requires_mut_receiver(),
             MemberBuiltin::Number(b) => b.requires_mut_receiver(),
+            MemberBuiltin::ProcessCommand(b) => b.requires_mut_receiver(),
+            MemberBuiltin::ProcessResult(b) => b.requires_mut_receiver(),
         }
     }
 }

--- a/src/builtins/process.rs
+++ b/src/builtins/process.rs
@@ -1,0 +1,119 @@
+use crate::builtins::Builtin;
+use crate::helpers::ValueType;
+
+/// Built-in methods for `process_command`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessCommandBuiltin {
+    Arg,
+    Cwd,
+    Env,
+    StdinText,
+    StdinInherit,
+    StdinNull,
+    StdoutCapture,
+    StdoutInherit,
+    StdoutNull,
+    StderrCapture,
+    StderrInherit,
+    StderrNull,
+    TimeoutMs,
+    Run,
+}
+
+impl Builtin for ProcessCommandBuiltin {
+    fn arity(&self) -> usize {
+        match self {
+            ProcessCommandBuiltin::Arg
+            | ProcessCommandBuiltin::Cwd
+            | ProcessCommandBuiltin::StdinText
+            | ProcessCommandBuiltin::TimeoutMs => 1,
+            ProcessCommandBuiltin::Env => 2,
+            ProcessCommandBuiltin::StdinInherit
+            | ProcessCommandBuiltin::StdinNull
+            | ProcessCommandBuiltin::StdoutCapture
+            | ProcessCommandBuiltin::StdoutInherit
+            | ProcessCommandBuiltin::StdoutNull
+            | ProcessCommandBuiltin::StderrCapture
+            | ProcessCommandBuiltin::StderrInherit
+            | ProcessCommandBuiltin::StderrNull
+            | ProcessCommandBuiltin::Run => 0,
+        }
+    }
+
+    fn return_type(&self) -> ValueType {
+        match self {
+            ProcessCommandBuiltin::Run => ValueType::ProcessResult,
+            ProcessCommandBuiltin::Arg
+            | ProcessCommandBuiltin::Cwd
+            | ProcessCommandBuiltin::Env
+            | ProcessCommandBuiltin::StdinText
+            | ProcessCommandBuiltin::StdinInherit
+            | ProcessCommandBuiltin::StdinNull
+            | ProcessCommandBuiltin::StdoutCapture
+            | ProcessCommandBuiltin::StdoutInherit
+            | ProcessCommandBuiltin::StdoutNull
+            | ProcessCommandBuiltin::StderrCapture
+            | ProcessCommandBuiltin::StderrInherit
+            | ProcessCommandBuiltin::StderrNull
+            | ProcessCommandBuiltin::TimeoutMs => ValueType::Null,
+        }
+    }
+
+    fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "arg" => Some(Self::Arg),
+            "cwd" => Some(Self::Cwd),
+            "env" => Some(Self::Env),
+            "stdin_text" => Some(Self::StdinText),
+            "stdin_inherit" => Some(Self::StdinInherit),
+            "stdin_null" => Some(Self::StdinNull),
+            "stdout_capture" => Some(Self::StdoutCapture),
+            "stdout_inherit" => Some(Self::StdoutInherit),
+            "stdout_null" => Some(Self::StdoutNull),
+            "stderr_capture" => Some(Self::StderrCapture),
+            "stderr_inherit" => Some(Self::StderrInherit),
+            "stderr_null" => Some(Self::StderrNull),
+            "timeout_ms" => Some(Self::TimeoutMs),
+            "run" => Some(Self::Run),
+            _ => None,
+        }
+    }
+
+    fn requires_mut_receiver(&self) -> bool {
+        !matches!(self, Self::Run)
+    }
+}
+
+/// Built-in methods for `process_result`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessResultBuiltin {
+    Success,
+    ExitCode,
+    Stdout,
+    Stderr,
+}
+
+impl Builtin for ProcessResultBuiltin {
+    fn arity(&self) -> usize {
+        0
+    }
+
+    fn return_type(&self) -> ValueType {
+        match self {
+            ProcessResultBuiltin::Success => ValueType::Bool,
+            ProcessResultBuiltin::ExitCode
+            | ProcessResultBuiltin::Stdout
+            | ProcessResultBuiltin::Stderr => ValueType::Dynamic,
+        }
+    }
+
+    fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "success" => Some(Self::Success),
+            "exit_code" => Some(Self::ExitCode),
+            "stdout" => Some(Self::Stdout),
+            "stderr" => Some(Self::Stderr),
+            _ => None,
+        }
+    }
+}

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -16,6 +16,8 @@ pub enum ValueType {
     String,
     Bool,
     Array,
+    ProcessCommand,
+    ProcessResult,
     Dynamic,
     Null,
 }
@@ -27,6 +29,8 @@ impl fmt::Display for ValueType {
             ValueType::String => write!(f, "string"),
             ValueType::Bool => write!(f, "boolean"),
             ValueType::Array => write!(f, "array"),
+            ValueType::ProcessCommand => write!(f, "process_command"),
+            ValueType::ProcessResult => write!(f, "process_result"),
             ValueType::Dynamic => write!(f, "dynamic"),
             ValueType::Null => write!(f, "null"),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod analysis;
 pub mod builtins;
 pub mod diagnostics;
 pub mod helpers;
+pub mod process;
 pub mod resolver;
 pub mod runtime;
 pub mod syntax;

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,0 +1,515 @@
+//! Process execution types, limits, and host policy.
+
+use std::ptr::NonNull;
+use std::{fmt, io};
+
+use crate::arena::{Arena, ArenaString, PoolSet};
+
+/// Hard limits for host process execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProcessCaps {
+    pub max_program_bytes: u32,
+    pub max_cwd_bytes: u32,
+    pub max_args: u32,
+    pub max_arg_bytes: u32,
+    pub max_total_arg_bytes: u32,
+    pub max_env_pairs: u32,
+    pub max_env_key_bytes: u32,
+    pub max_env_value_bytes: u32,
+    pub max_total_env_bytes: u32,
+    pub max_stdin_bytes: u32,
+    pub max_capture_bytes_per_stream: u32,
+    pub default_timeout_ms: u32,
+    pub max_timeout_ms: u32,
+    pub wait_poll_ms: u32,
+}
+
+impl ProcessCaps {
+    #[must_use]
+    pub const fn defaults() -> Self {
+        Self {
+            max_program_bytes: 4_096,
+            max_cwd_bytes: 4_096,
+            max_args: 256,
+            max_arg_bytes: 65_536,
+            max_total_arg_bytes: 262_144,
+            max_env_pairs: 128,
+            max_env_key_bytes: 256,
+            max_env_value_bytes: 16_384,
+            max_total_env_bytes: 131_072,
+            max_stdin_bytes: 1_048_576,
+            max_capture_bytes_per_stream: 1_048_576,
+            default_timeout_ms: 900_000,
+            max_timeout_ms: 3_600_000,
+            wait_poll_ms: 10,
+        }
+    }
+}
+
+/// Host capability policy injected by the embedding runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HostPolicy {
+    pub allow_process: bool,
+    pub process: ProcessCaps,
+}
+
+impl HostPolicy {
+    #[must_use]
+    pub const fn native_default() -> Self {
+        Self { allow_process: true, process: ProcessCaps::defaults() }
+    }
+
+    #[must_use]
+    pub const fn wasm_default() -> Self {
+        Self { allow_process: false, process: ProcessCaps::defaults() }
+    }
+
+    #[must_use]
+    pub const fn target_default() -> Self {
+        #[cfg(target_family = "wasm")]
+        {
+            Self::wasm_default()
+        }
+        #[cfg(not(target_family = "wasm"))]
+        {
+            Self::native_default()
+        }
+    }
+}
+
+impl Default for HostPolicy {
+    fn default() -> Self {
+        Self::target_default()
+    }
+}
+
+/// Child stdin configuration.
+#[derive(Debug, Clone)]
+pub enum StdinPolicy<'a> {
+    Inherit,
+    Null,
+    Text(ArenaString<'a>),
+}
+
+/// Child stdout or stderr configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputPolicy {
+    Inherit,
+    Null,
+    Capture,
+}
+
+/// One environment variable override.
+#[derive(Debug, Clone)]
+pub struct EnvPair<'a> {
+    pub key: ArenaString<'a>,
+    pub value: ArenaString<'a>,
+}
+
+impl EnvPair<'_> {
+    #[must_use]
+    pub fn clone_into<'b>(&self, arena: &'b Arena) -> EnvPair<'b> {
+        EnvPair {
+            key: ArenaString::from_str(arena, self.key.as_str()),
+            value: ArenaString::from_str(arena, self.value.as_str()),
+        }
+    }
+}
+
+/// User-visible process command builder.
+#[derive(Debug, Clone)]
+pub struct ProcessCommand<'a> {
+    pub program: ArenaString<'a>,
+    pub args: Vec<ArenaString<'a>, &'a Arena>,
+    pub cwd: Option<ArenaString<'a>>,
+    pub env: Vec<EnvPair<'a>, &'a Arena>,
+    pub stdin: StdinPolicy<'a>,
+    pub stdout: OutputPolicy,
+    pub stderr: OutputPolicy,
+    pub timeout_ms: Option<u32>,
+}
+
+impl<'a> ProcessCommand<'a> {
+    #[must_use]
+    pub fn new(program: &str, arena: &'a Arena) -> Self {
+        Self {
+            program: ArenaString::from_str(arena, program),
+            args: Vec::new_in(arena),
+            cwd: None,
+            env: Vec::new_in(arena),
+            stdin: StdinPolicy::Inherit,
+            stdout: OutputPolicy::Inherit,
+            stderr: OutputPolicy::Inherit,
+            timeout_ms: None,
+        }
+    }
+
+    pub fn push_arg(&mut self, arg: ArenaString<'a>) {
+        self.args.push(arg);
+    }
+
+    pub fn set_cwd(&mut self, cwd: ArenaString<'a>) {
+        self.cwd = Some(cwd);
+    }
+
+    pub fn set_env(&mut self, key: ArenaString<'a>, value: ArenaString<'a>) {
+        if let Some(pair) = self.env.iter_mut().rev().find(|pair| pair.key == key.as_str()) {
+            pair.value = value;
+        } else {
+            self.env.push(EnvPair { key, value });
+        }
+    }
+
+    pub fn set_stdin_text(&mut self, text: ArenaString<'a>) {
+        self.stdin = StdinPolicy::Text(text);
+    }
+
+    pub fn set_stdin_policy(&mut self, policy: StdinPolicy<'a>) {
+        self.stdin = policy;
+    }
+
+    pub fn set_stdout_policy(&mut self, policy: OutputPolicy) {
+        self.stdout = policy;
+    }
+
+    pub fn set_stderr_policy(&mut self, policy: OutputPolicy) {
+        self.stderr = policy;
+    }
+
+    pub fn set_timeout_ms(&mut self, timeout_ms: u32) {
+        self.timeout_ms = Some(timeout_ms);
+    }
+
+    #[must_use]
+    pub fn clone_into<'b>(&self, arena: &'b Arena) -> ProcessCommand<'b> {
+        let mut args = Vec::with_capacity_in(self.args.len(), arena);
+        for arg in &self.args {
+            args.push(ArenaString::from_str(arena, arg.as_str()));
+        }
+
+        let mut env = Vec::with_capacity_in(self.env.len(), arena);
+        for pair in &self.env {
+            env.push(pair.clone_into(arena));
+        }
+
+        let stdin = match &self.stdin {
+            StdinPolicy::Inherit => StdinPolicy::Inherit,
+            StdinPolicy::Null => StdinPolicy::Null,
+            StdinPolicy::Text(text) => StdinPolicy::Text(ArenaString::from_str(arena, text)),
+        };
+
+        ProcessCommand {
+            program: ArenaString::from_str(arena, self.program.as_str()),
+            args,
+            cwd: self.cwd.as_ref().map(|cwd| ArenaString::from_str(arena, cwd.as_str())),
+            env,
+            stdin,
+            stdout: self.stdout,
+            stderr: self.stderr,
+            timeout_ms: self.timeout_ms,
+        }
+    }
+
+    pub fn validate<'b>(&'b self, caps: &ProcessCaps) -> Result<ProcessSpec<'b>, ProcessError> {
+        validate_named_text(
+            "program",
+            self.program.as_str(),
+            caps.max_program_bytes,
+            false,
+            false,
+        )?;
+        validate_count(self.args.len(), caps.max_args, "argument count")?;
+        validate_count(self.env.len(), caps.max_env_pairs, "environment pair count")?;
+
+        let mut total_arg_bytes = 0u32;
+        for arg in &self.args {
+            let len =
+                validate_named_text("argument", arg.as_str(), caps.max_arg_bytes, true, false)?;
+            total_arg_bytes = total_arg_bytes
+                .checked_add(len)
+                .ok_or(ProcessError::SpecInvalid("Argument bytes pass configured limit"))?;
+        }
+        if total_arg_bytes > caps.max_total_arg_bytes {
+            return Err(ProcessError::SpecInvalid("Argument bytes pass configured limit"));
+        }
+
+        let cwd = match &self.cwd {
+            Some(cwd) => {
+                validate_named_text("cwd", cwd.as_str(), caps.max_cwd_bytes, false, false)?;
+                Some(cwd.as_str())
+            }
+            None => None,
+        };
+
+        let mut total_env_bytes = 0u32;
+        for pair in &self.env {
+            let key_len = validate_named_text(
+                "environment key",
+                pair.key.as_str(),
+                caps.max_env_key_bytes,
+                false,
+                true,
+            )?;
+            let value_len = validate_named_text(
+                "environment value",
+                pair.value.as_str(),
+                caps.max_env_value_bytes,
+                true,
+                false,
+            )?;
+            total_env_bytes = total_env_bytes
+                .checked_add(key_len)
+                .and_then(|value| value.checked_add(value_len))
+                .ok_or(ProcessError::SpecInvalid("Environment bytes pass configured limit"))?;
+        }
+        if total_env_bytes > caps.max_total_env_bytes {
+            return Err(ProcessError::SpecInvalid("Environment bytes pass configured limit"));
+        }
+
+        match &self.stdin {
+            StdinPolicy::Text(text) => {
+                validate_named_text(
+                    "stdin text",
+                    text.as_str(),
+                    caps.max_stdin_bytes,
+                    true,
+                    false,
+                )?;
+            }
+            StdinPolicy::Inherit | StdinPolicy::Null => {}
+        }
+
+        let timeout_ms = self.timeout_ms.unwrap_or(caps.default_timeout_ms);
+        if timeout_ms == 0 {
+            return Err(ProcessError::SpecInvalid("Timeout must be positive"));
+        }
+        if timeout_ms > caps.max_timeout_ms {
+            return Err(ProcessError::SpecInvalid("Timeout pass configured limit"));
+        }
+
+        Ok(ProcessSpec {
+            program: self.program.as_str(),
+            args: &self.args,
+            cwd,
+            env: &self.env,
+            stdin: &self.stdin,
+            stdout: self.stdout,
+            stderr: self.stderr,
+            timeout_ms,
+        })
+    }
+}
+
+/// Host-backed runtime values exposed to scripts.
+#[derive(Debug, Clone, PartialEq)]
+pub enum HostValue<'a> {
+    ProcessCommand(ProcessCommand<'a>),
+    ProcessResult(ProcessResult<'a>),
+}
+
+/// Arena-backed indirection that keeps host values out of the hot interpreter value layout.
+#[derive(Debug)]
+pub struct HostHandle<'a>(NonNull<HostValue<'a>>);
+
+impl HostValue<'_> {
+    #[must_use]
+    pub fn clone_into<'b>(&self, arena: &'b Arena) -> HostValue<'b> {
+        match self {
+            HostValue::ProcessCommand(command) => {
+                HostValue::ProcessCommand(command.clone_into(arena))
+            }
+            HostValue::ProcessResult(result) => HostValue::ProcessResult(result.clone_into(arena)),
+        }
+    }
+}
+
+impl fmt::Display for HostValue<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            HostValue::ProcessCommand(command) => {
+                write!(
+                    f,
+                    "<process_command program=\"{}\" args={}>",
+                    command.program,
+                    command.args.len()
+                )
+            }
+            HostValue::ProcessResult(result) => {
+                if let Some(code) = result.exit_code {
+                    write!(f, "<process_result success={} exit={code}>", result.success)
+                } else {
+                    write!(f, "<process_result success={} exit=null>", result.success)
+                }
+            }
+        }
+    }
+}
+
+impl<'a> HostHandle<'a> {
+    #[must_use]
+    pub(crate) fn new_in(arena: &'a Arena, value: HostValue<'a>) -> Self {
+        let slot = arena.alloc_uninit::<HostValue<'a>>();
+        Self(NonNull::from(slot.write(value)))
+    }
+
+    #[must_use]
+    pub(crate) fn get(&self) -> &HostValue<'a> {
+        unsafe { self.0.as_ref() }
+    }
+
+    #[must_use]
+    pub(crate) fn get_mut(&mut self) -> &mut HostValue<'a> {
+        unsafe { self.0.as_mut() }
+    }
+
+    #[must_use]
+    pub(crate) fn clone_into<'b>(&self, arena: &'b Arena) -> HostHandle<'b> {
+        HostHandle::new_in(arena, self.get().clone_into(arena))
+    }
+
+    #[must_use]
+    pub(crate) fn promote(self, pool: &PoolSet<'a>, frame: &Arena) -> HostHandle<'a> {
+        if !frame.contains_ptr(self.0.as_ptr().cast::<u8>().cast_const()) {
+            return self;
+        }
+        HostHandle::new_in(pool.arena(), self.get().clone_into(pool.arena()))
+    }
+}
+
+impl PartialEq for HostHandle<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.get() == other.get()
+    }
+}
+
+/// User-visible process result.
+#[derive(Debug, Clone)]
+pub struct ProcessResult<'a> {
+    pub success: bool,
+    pub exit_code: Option<i32>,
+    pub stdout: Option<ArenaString<'a>>,
+    pub stderr: Option<ArenaString<'a>>,
+}
+
+impl PartialEq for StdinPolicy<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (StdinPolicy::Inherit, StdinPolicy::Inherit)
+            | (StdinPolicy::Null, StdinPolicy::Null) => true,
+            (StdinPolicy::Text(lhs), StdinPolicy::Text(rhs)) => lhs.as_str() == rhs.as_str(),
+            _ => false,
+        }
+    }
+}
+
+impl PartialEq for EnvPair<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.key.as_str() == other.key.as_str() && self.value.as_str() == other.value.as_str()
+    }
+}
+
+impl PartialEq for ProcessCommand<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.program.as_str() == other.program.as_str()
+            && self.args.len() == other.args.len()
+            && self.args.iter().zip(&other.args).all(|(lhs, rhs)| lhs.as_str() == rhs.as_str())
+            && self.cwd.as_ref().map(ArenaString::as_str)
+                == other.cwd.as_ref().map(ArenaString::as_str)
+            && self.env == other.env
+            && self.stdin == other.stdin
+            && self.stdout == other.stdout
+            && self.stderr == other.stderr
+            && self.timeout_ms == other.timeout_ms
+    }
+}
+
+impl PartialEq for ProcessResult<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.success == other.success
+            && self.exit_code == other.exit_code
+            && self.stdout.as_ref().map(ArenaString::as_str)
+                == other.stdout.as_ref().map(ArenaString::as_str)
+            && self.stderr.as_ref().map(ArenaString::as_str)
+                == other.stderr.as_ref().map(ArenaString::as_str)
+    }
+}
+
+impl ProcessResult<'_> {
+    #[must_use]
+    pub fn clone_into<'b>(&self, arena: &'b Arena) -> ProcessResult<'b> {
+        ProcessResult {
+            success: self.success,
+            exit_code: self.exit_code,
+            stdout: self.stdout.as_ref().map(|stdout| ArenaString::from_str(arena, stdout)),
+            stderr: self.stderr.as_ref().map(|stderr| ArenaString::from_str(arena, stderr)),
+        }
+    }
+}
+
+/// Immutable command specification passed into the platform backend.
+#[derive(Debug, Clone, Copy)]
+pub struct ProcessSpec<'a> {
+    pub program: &'a str,
+    pub args: &'a [ArenaString<'a>],
+    pub cwd: Option<&'a str>,
+    pub env: &'a [EnvPair<'a>],
+    pub stdin: &'a StdinPolicy<'a>,
+    pub stdout: OutputPolicy,
+    pub stderr: OutputPolicy,
+    pub timeout_ms: u32,
+}
+
+/// Stream identifier for process-related diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessStream {
+    Stdout,
+    Stderr,
+}
+
+impl ProcessStream {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            ProcessStream::Stdout => "stdout",
+            ProcessStream::Stderr => "stderr",
+        }
+    }
+}
+
+/// Process execution failure reported by the backend.
+#[derive(Debug)]
+pub enum ProcessError {
+    Unsupported,
+    Denied,
+    SpawnFailed(io::Error),
+    Timeout,
+    OutputLimitExceeded(ProcessStream),
+    InvalidUtf8(ProcessStream),
+    SpecInvalid(&'static str),
+}
+
+fn validate_count(len: usize, max: u32, name: &'static str) -> Result<(), ProcessError> {
+    let len = u32::try_from(len).map_err(|_| ProcessError::SpecInvalid(name))?;
+    if len > max { Err(ProcessError::SpecInvalid(name)) } else { Ok(()) }
+}
+
+fn validate_named_text(
+    name: &'static str,
+    value: &str,
+    max_bytes: u32,
+    allow_empty: bool,
+    forbid_equals: bool,
+) -> Result<u32, ProcessError> {
+    if !allow_empty && value.is_empty() {
+        return Err(ProcessError::SpecInvalid(name));
+    }
+    if value.contains('\0') {
+        return Err(ProcessError::SpecInvalid(name));
+    }
+    if forbid_equals && value.contains('=') {
+        return Err(ProcessError::SpecInvalid(name));
+    }
+
+    let len = u32::try_from(value.len()).map_err(|_| ProcessError::SpecInvalid(name))?;
+    if len > max_bytes { Err(ProcessError::SpecInvalid(name)) } else { Ok(len) }
+}

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -12,7 +12,8 @@ use crate::analysis::{
 use crate::arena::{Arena, ArenaCow};
 use crate::arena_format;
 use crate::builtins::{
-    ArrayBuiltin, Builtin, GlobalBuiltin, MemberBuiltin, NumberBuiltin, StringBuiltin,
+    ArrayBuiltin, Builtin, GlobalBuiltin, MemberBuiltin, NumberBuiltin, ProcessCommandBuiltin,
+    ProcessResultBuiltin, StringBuiltin,
 };
 use crate::diagnostics::{AsStr, Diagnostics, Label, Severity, Span};
 use crate::helpers::ValueType;
@@ -675,6 +676,44 @@ impl<'ast, 'res> Resolver<'ast, 'res> {
         }
     }
 
+    fn expect_member_string_arg(&mut self, field: &str, arg: ExprRef<'ast>, span: Span) {
+        if let Some(arg_ty) = self.infer_expr_type(arg)
+            && arg_ty != ValueType::String
+            && arg_ty != ValueType::Dynamic
+        {
+            self.emit_error(
+                span,
+                SemanticError::TypeMismatch,
+                vec![Label {
+                    span,
+                    message: ArenaCow::Owned(arena_format!(
+                        self.arena,
+                        "Method `{field}` dey expect string but na {arg_ty} dey here",
+                    )),
+                }],
+            );
+        }
+    }
+
+    fn expect_member_number_arg(&mut self, field: &str, arg: ExprRef<'ast>, span: Span) {
+        if let Some(arg_ty) = self.infer_expr_type(arg)
+            && arg_ty != ValueType::Number
+            && arg_ty != ValueType::Dynamic
+        {
+            self.emit_error(
+                span,
+                SemanticError::TypeMismatch,
+                vec![Label {
+                    span,
+                    message: ArenaCow::Owned(arena_format!(
+                        self.arena,
+                        "Method `{field}` dey expect number but na {arg_ty} dey here",
+                    )),
+                }],
+            );
+        }
+    }
+
     #[inline]
     fn check_expr(&mut self, expr: ExprRef<'ast>) {
         match expr {
@@ -908,6 +947,23 @@ impl<'ast, 'res> Resolver<'ast, 'res> {
                                     }],
                                 );
                             }
+                            if matches!(builtin, GlobalBuiltin::Command)
+                                && !args.args.is_empty()
+                                && let Some(arg_ty) = self.infer_expr_type(args.args[0])
+                                && arg_ty != ValueType::String
+                                && arg_ty != ValueType::Dynamic
+                            {
+                                self.emit_error(
+                                    *span,
+                                    SemanticError::TypeMismatch,
+                                    vec![Label {
+                                        span: *span,
+                                        message: ArenaCow::Borrowed(
+                                            "Function `command` dey expect string",
+                                        ),
+                                    }],
+                                );
+                            }
                         } else if let Some((callee_id, arity)) =
                             self.lookup_func(func_name).map(|sig| (sig.id, sig.param_names.len()))
                         {
@@ -960,17 +1016,34 @@ impl<'ast, 'res> Resolver<'ast, 'res> {
                                 ValueType::Number => {
                                     NumberBuiltin::from_name(field).map(MemberBuiltin::Number)
                                 }
+                                ValueType::ProcessCommand => {
+                                    ProcessCommandBuiltin::from_name(field)
+                                        .map(MemberBuiltin::ProcessCommand)
+                                }
+                                ValueType::ProcessResult => ProcessResultBuiltin::from_name(field)
+                                    .map(MemberBuiltin::ProcessResult),
                                 ValueType::Bool | ValueType::Null | ValueType::Dynamic => None,
                             };
 
                             if let Some(builtin) = builtin {
-                                if builtin.requires_mut_receiver()
-                                    && let Some(local_id) = self.expr_root_local(object)
-                                {
-                                    self.record_stmt_read(local_id);
-                                    self.record_stmt_write(local_id);
-                                    self.record_capture_read(local_id);
-                                    self.record_capture_write(local_id);
+                                if builtin.requires_mut_receiver() {
+                                    if let Some(local_id) = self.expr_root_local(object) {
+                                        self.record_stmt_read(local_id);
+                                        self.record_stmt_write(local_id);
+                                        self.record_capture_read(local_id);
+                                        self.record_capture_write(local_id);
+                                    } else if matches!(builtin, MemberBuiltin::ProcessCommand(..)) {
+                                        self.emit_error(
+                                            *span,
+                                            SemanticError::TypeMismatch,
+                                            vec![Label {
+                                                span: *span,
+                                                message: ArenaCow::Borrowed(
+                                                    "Dis method need variable or array slot receiver",
+                                                ),
+                                            }],
+                                        );
+                                    }
                                 }
                                 if args.args.len() != builtin.arity() {
                                     self.emit_error(
@@ -987,27 +1060,27 @@ impl<'ast, 'res> Resolver<'ast, 'res> {
                                                 args.args.len()
                                             )),
                                         }],
-                                    );
+                                                );
                                 }
 
-                                // TODO: Extend Builtin trait with arg_types() method for generic argument type validation
-                                if matches!(builtin, MemberBuiltin::Array(ArrayBuiltin::Join))
-                                    && !args.args.is_empty()
-                                    && let Some(arg_ty) = self.infer_expr_type(args.args[0])
-                                    && arg_ty != ValueType::String
-                                    && arg_ty != ValueType::Dynamic
-                                {
-                                    self.emit_error(
-                                                    *span,
-                                                    SemanticError::TypeMismatch,
-                                                    vec![Label {
-                                                        span: *span,
-                                                        message: ArenaCow::Owned(arena_format!(
-                                                            self.arena,
-                                                            "Method `{field}` dey expect string but na {arg_ty} dey here",
-                                                        )),
-                                                    }],
-                                                );
+                                match builtin {
+                                    MemberBuiltin::ProcessCommand(ProcessCommandBuiltin::Cwd)
+                                    | MemberBuiltin::Array(ArrayBuiltin::Join)
+                                        if !args.args.is_empty() =>
+                                    {
+                                        self.expect_member_string_arg(field, args.args[0], *span);
+                                    }
+                                    MemberBuiltin::ProcessCommand(ProcessCommandBuiltin::Env)
+                                        if args.args.len() >= 2 =>
+                                    {
+                                        self.expect_member_string_arg(field, args.args[0], *span);
+                                    }
+                                    MemberBuiltin::ProcessCommand(
+                                        ProcessCommandBuiltin::TimeoutMs,
+                                    ) if !args.args.is_empty() => {
+                                        self.expect_member_number_arg(field, args.args[0], *span);
+                                    }
+                                    _ => {}
                                 }
                             } else {
                                 // We defer method validation at runtime for dynamic receivers
@@ -1177,11 +1250,32 @@ impl<'ast, 'res> Resolver<'ast, 'res> {
                         self.lookup_func(func_name).map(|func_sig| func_sig.return_type)
                     }
                 }
-                Expr::Member { field, .. } => {
-                    if let Some(builtin) = MemberBuiltin::from_name(field) {
-                        Some(builtin.return_type())
-                    } else {
-                        Some(ValueType::Dynamic)
+                Expr::Member { object, field, .. } => {
+                    let receiver_ty = self.infer_expr_type(object)?;
+                    match receiver_ty {
+                        ValueType::String => StringBuiltin::from_name(field)
+                            .map_or(Some(ValueType::Dynamic), |builtin| {
+                                Some(builtin.return_type())
+                            }),
+                        ValueType::Array => ArrayBuiltin::from_name(field)
+                            .map_or(Some(ValueType::Dynamic), |builtin| {
+                                Some(builtin.return_type())
+                            }),
+                        ValueType::Number => NumberBuiltin::from_name(field)
+                            .map_or(Some(ValueType::Dynamic), |builtin| {
+                                Some(builtin.return_type())
+                            }),
+                        ValueType::ProcessCommand => ProcessCommandBuiltin::from_name(field)
+                            .map_or(Some(ValueType::Dynamic), |builtin| {
+                                Some(builtin.return_type())
+                            }),
+                        ValueType::ProcessResult => ProcessResultBuiltin::from_name(field)
+                            .map_or(Some(ValueType::Dynamic), |builtin| {
+                                Some(builtin.return_type())
+                            }),
+                        ValueType::Bool | ValueType::Null | ValueType::Dynamic => {
+                            Some(ValueType::Dynamic)
+                        }
                     }
                 }
                 _ => None,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -10,7 +10,8 @@ use crate::analysis::opt::OptimizationPlan;
 use crate::arena::{Arena, ArenaCow, ArenaString, PoolSet};
 use crate::arena_format;
 use crate::builtins::{
-    ArrayBuiltin, Builtin, GlobalBuiltin, MemberBuiltin, NumberBuiltin, StringBuiltin,
+    ArrayBuiltin, Builtin, GlobalBuiltin, NumberBuiltin, ProcessCommandBuiltin,
+    ProcessResultBuiltin, StringBuiltin,
 };
 use crate::diagnostics::{AsStr, Diagnostics, Label, Severity, Span};
 #[cfg(target_family = "wasm")]
@@ -18,10 +19,15 @@ use crate::helpers::KIBI;
 use crate::helpers::LenWriter;
 #[cfg(not(target_family = "wasm"))]
 use crate::helpers::MEBI;
+use crate::process::{
+    HostHandle, HostPolicy, HostValue, OutputPolicy, ProcessCommand, ProcessError, ProcessResult,
+    StdinPolicy,
+};
 use crate::syntax::parser::{
     ArgList, BinaryOp, BlockRef, Expr, ExprRef, ParamListRef, Stmt, StmtRef, StringParts,
     StringSegment, UnaryOp,
 };
+use crate::sys::{self, ProcessRunner};
 
 /// Runtime errors that can occur during code execution.
 #[derive(Debug, PartialEq, Eq)]
@@ -33,6 +39,13 @@ pub enum RuntimeErrorKind {
     /// Type mismatch error that can't be caught in semantic analysis
     TypeMismatch,
     InvalidIndex,
+    ProcessUnsupported,
+    ProcessDenied,
+    ProcessSpawnFailed(&'static str),
+    ProcessTimeout,
+    ProcessOutputLimitExceeded(&'static str),
+    ProcessInvalidUtf8(&'static str),
+    ProcessSpecInvalid(&'static str),
 }
 
 impl AsStr for RuntimeErrorKind {
@@ -44,6 +57,13 @@ impl AsStr for RuntimeErrorKind {
             RuntimeErrorKind::IndexOutOfBounds => "Index out of bounds",
             RuntimeErrorKind::TypeMismatch => "Type mismatch",
             RuntimeErrorKind::InvalidIndex => "Invalid index",
+            RuntimeErrorKind::ProcessUnsupported => "Unsupported process execution",
+            RuntimeErrorKind::ProcessDenied => "Process execution denied",
+            RuntimeErrorKind::ProcessSpawnFailed(..) => "Process spawn failed",
+            RuntimeErrorKind::ProcessTimeout => "Process timeout",
+            RuntimeErrorKind::ProcessOutputLimitExceeded(..) => "Process output limit exceeded",
+            RuntimeErrorKind::ProcessInvalidUtf8(..) => "Process output no be valid UTF-8",
+            RuntimeErrorKind::ProcessSpecInvalid(..) => "Invalid process configuration",
         }
     }
 }
@@ -94,7 +114,7 @@ const STACK_BUDGET: usize = 4 * MEBI;
 const FLOAT_EQ_EPS: f64 = 1e-12;
 
 /// The value types our runtime can work with at runtime.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum Value<'a> {
     /// String literals reference original source when possible
     Str(ArenaCow<'a>),
@@ -104,6 +124,8 @@ pub enum Value<'a> {
     Bool(bool),
     /// Array literal values
     Array(Vec<Value<'a>, &'a Arena>),
+    /// Host-backed values exposed to scripts.
+    Host(HostHandle<'a>),
     /// Represents the absence of a value
     Null,
 }
@@ -116,6 +138,7 @@ impl<'a> Value<'a> {
             Value::Str(cow) => Value::Str(cow.clone()),
             Value::Number(n) => Value::Number(*n),
             Value::Bool(b) => Value::Bool(*b),
+            Value::Host(host) => Value::Host(host.clone_into(arena)),
             Value::Null => Value::Null,
             Value::Array(items) => {
                 let mut new = Vec::with_capacity_in(items.len(), arena);
@@ -158,6 +181,7 @@ impl<'a> Value<'a> {
             Value::Bool(b) => Value::Bool(b),
             Value::Null => Value::Null,
             Value::Str(cow) => Value::Str(cow.promote(pool, frame)),
+            Value::Host(host) => Value::Host(host.promote(pool, frame)),
             Value::Array(items) => {
                 let mut promoted = Vec::with_capacity_in(items.len(), pool.arena());
                 for item in items {
@@ -188,6 +212,7 @@ impl fmt::Display for Value<'_> {
                 }
                 write!(f, "]")
             }
+            Value::Host(host) => write!(f, "{}", host.get()),
             Value::Null => write!(f, "null"),
         }
     }
@@ -209,7 +234,7 @@ struct LocalSlot<'a> {
 }
 
 // Controls how function execution should proceed after statements
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, PartialEq)]
 enum ExecFlow<'a> {
     Continue,
     Return(Value<'a>),
@@ -249,6 +274,9 @@ pub struct Runtime<'a> {
     // Optional conservative optimization plan used for safe statement and function pruning.
     optimization_plan: Option<NonNull<OptimizationPlan<'a>>>,
 
+    // Host capability policy for process execution and future host-backed features.
+    host_policy: HostPolicy,
+
     #[cfg(test)]
     skipped_stmt_count: u32,
 }
@@ -258,6 +286,15 @@ impl<'a> Runtime<'a> {
     /// If `frame` is `None`, the persistent arena is used for both roles
     /// (no frame resets, identical to pre-frame-arena behavior).
     pub fn new(arena: &'a Arena, frame: Option<&'a Arena>) -> Self {
+        Self::new_with_host_policy(arena, frame, HostPolicy::default())
+    }
+
+    /// Creates a new [`Runtime`] instance with the given host capability policy.
+    pub fn new_with_host_policy(
+        arena: &'a Arena,
+        frame: Option<&'a Arena>,
+        host_policy: HostPolicy,
+    ) -> Self {
         let frame = frame.unwrap_or(arena);
         let pool = PoolSet::new(arena);
         Self {
@@ -271,6 +308,7 @@ impl<'a> Runtime<'a> {
             stack_base: 0,
             facts: None,
             optimization_plan: None,
+            host_policy,
             #[cfg(test)]
             skipped_stmt_count: 0,
         }
@@ -334,7 +372,9 @@ impl<'a> Runtime<'a> {
                             message: ArenaCow::Borrowed("Call stack don full"),
                         }]
                     }
-                    RuntimeErrorKind::Io(msg) => {
+                    RuntimeErrorKind::Io(msg)
+                    | RuntimeErrorKind::ProcessSpawnFailed(msg)
+                    | RuntimeErrorKind::ProcessSpecInvalid(msg) => {
                         vec![Label { span: err.span, message: ArenaCow::Borrowed(msg) }]
                     }
                     RuntimeErrorKind::IndexOutOfBounds => vec![Label {
@@ -353,6 +393,34 @@ impl<'a> Runtime<'a> {
                     RuntimeErrorKind::InvalidIndex => vec![Label {
                         span: err.span,
                         message: ArenaCow::Borrowed("Index value no be whole number"),
+                    }],
+                    RuntimeErrorKind::ProcessUnsupported => vec![Label {
+                        span: err.span,
+                        message: ArenaCow::Borrowed("Dis platform no support process execution"),
+                    }],
+                    RuntimeErrorKind::ProcessDenied => vec![Label {
+                        span: err.span,
+                        message: ArenaCow::Borrowed("Host policy no allow process execution"),
+                    }],
+                    RuntimeErrorKind::ProcessTimeout => vec![Label {
+                        span: err.span,
+                        message: ArenaCow::Borrowed(
+                            "Process timeout finish before command complete",
+                        ),
+                    }],
+                    RuntimeErrorKind::ProcessOutputLimitExceeded(stream) => vec![Label {
+                        span: err.span,
+                        message: ArenaCow::Owned(arena_format!(
+                            self.arena,
+                            "Process output for {stream} pass the configured capture limit"
+                        )),
+                    }],
+                    RuntimeErrorKind::ProcessInvalidUtf8(stream) => vec![Label {
+                        span: err.span,
+                        message: ArenaCow::Owned(arena_format!(
+                            self.arena,
+                            "Captured {stream} no be valid UTF-8 text"
+                        )),
                     }],
                 };
                 self.errors.emit(err.span, Severity::Error, "runtime", err.kind.as_str(), labels);
@@ -808,6 +876,15 @@ impl<'a> Runtime<'a> {
                 let s = GlobalBuiltin::to_string(self.frame, &arg_values[0]);
                 Ok(Value::Str(ArenaCow::owned(s)))
             }
+            GlobalBuiltin::Command => {
+                let Value::Str(program) = &arg_values[0] else {
+                    unreachable!("Semantic analysis guarantees string arg")
+                };
+                Ok(Value::Host(HostHandle::new_in(
+                    self.frame,
+                    HostValue::ProcessCommand(ProcessCommand::new(program, self.frame)),
+                )))
+            }
         }
     }
 
@@ -818,37 +895,73 @@ impl<'a> Runtime<'a> {
         args: &'a ArgList<'a>,
         span: Span,
     ) -> Result<Value<'a>, RuntimeError> {
-        let Some(builtin) = MemberBuiltin::from_name(field) else {
-            let receiver = self.eval_expr(object)?;
-            return Err(RuntimeError::new_with_extras(
-                RuntimeErrorKind::TypeMismatch,
-                span,
-                field,
-                GlobalBuiltin::type_of(&receiver),
-            ));
-        };
-
-        // Mutable methods go directly to the mutable path without cloning the receiver.
-        if builtin.requires_mut_receiver() {
-            match builtin {
-                MemberBuiltin::Array(array_builtin) => {
-                    return self.eval_array_member_call_mut(
-                        object,
-                        array_builtin,
-                        field,
-                        args,
-                        span,
-                    );
-                }
-                _ => unreachable!("Only array methods require mutable receiver"),
-            }
+        // Mutable methods stay name-directed so lvalue receivers and index expressions are
+        // evaluated only on the mutation path.
+        if let Some(array_builtin) = ArrayBuiltin::from_name(field)
+            && array_builtin.requires_mut_receiver()
+        {
+            return self.eval_array_member_call_mut(object, array_builtin, field, args, span);
+        }
+        if let Some(command_builtin) = ProcessCommandBuiltin::from_name(field)
+            && command_builtin.requires_mut_receiver()
+        {
+            return self.eval_process_command_call_mut(object, command_builtin, field, args, span);
         }
 
         let receiver = self.eval_expr(object)?;
         match receiver {
-            Value::Str(s) => self.eval_string_member_call(&s, field, args),
-            Value::Number(n) => Ok(Self::eval_number_member_call(n, field)),
-            Value::Array(arr) => self.eval_array_member_call(&arr, field, args),
+            Value::Str(ref s) => match StringBuiltin::from_name(field) {
+                Some(..) => self.eval_string_member_call(s, field, args),
+                None => Err(RuntimeError::new_with_extras(
+                    RuntimeErrorKind::TypeMismatch,
+                    span,
+                    field,
+                    GlobalBuiltin::type_of(&receiver),
+                )),
+            },
+            Value::Number(n) => match NumberBuiltin::from_name(field) {
+                Some(..) => Ok(Self::eval_number_member_call(n, field)),
+                None => Err(RuntimeError::new_with_extras(
+                    RuntimeErrorKind::TypeMismatch,
+                    span,
+                    field,
+                    GlobalBuiltin::type_of(&receiver),
+                )),
+            },
+            Value::Array(ref arr) => match ArrayBuiltin::from_name(field) {
+                Some(..) => self.eval_array_member_call(arr, field, args),
+                None => Err(RuntimeError::new_with_extras(
+                    RuntimeErrorKind::TypeMismatch,
+                    span,
+                    field,
+                    GlobalBuiltin::type_of(&receiver),
+                )),
+            },
+            Value::Host(ref host) => match host.get() {
+                HostValue::ProcessCommand(command) => match ProcessCommandBuiltin::from_name(field)
+                {
+                    Some(command_builtin) => {
+                        self.eval_process_command_call(command, command_builtin, args, span)
+                    }
+                    None => Err(RuntimeError::new_with_extras(
+                        RuntimeErrorKind::TypeMismatch,
+                        span,
+                        field,
+                        GlobalBuiltin::type_of(&receiver),
+                    )),
+                },
+                HostValue::ProcessResult(result) => match ProcessResultBuiltin::from_name(field) {
+                    Some(result_builtin) => {
+                        Ok(self.eval_process_result_call(result, result_builtin))
+                    }
+                    None => Err(RuntimeError::new_with_extras(
+                        RuntimeErrorKind::TypeMismatch,
+                        span,
+                        field,
+                        GlobalBuiltin::type_of(&receiver),
+                    )),
+                },
+            },
             Value::Bool(..) => unimplemented!("Boolean methods not implemented yet"),
             Value::Null => Err(RuntimeError::new_with_extras(
                 RuntimeErrorKind::TypeMismatch,
@@ -896,6 +1009,95 @@ impl<'a> Runtime<'a> {
         }
     }
 
+    fn eval_process_command_call_mut(
+        &mut self,
+        receiver: ExprRef<'a>,
+        builtin: ProcessCommandBuiltin,
+        field: &'a str,
+        args: &'a ArgList<'a>,
+        span: Span,
+    ) -> Result<Value<'a>, RuntimeError> {
+        match builtin {
+            ProcessCommandBuiltin::Arg => {
+                let value = self.eval_expr(args.args[0])?;
+                let arg = GlobalBuiltin::to_string(self.arena, &value);
+                let command = self.get_mutable_process_command(receiver, span, field)?;
+                command.push_arg(arg);
+                Ok(Value::Null)
+            }
+            ProcessCommandBuiltin::Cwd => {
+                let path = self.eval_required_string(args.args[0], span)?;
+                let command = self.get_mutable_process_command(receiver, span, field)?;
+                command.set_cwd(path);
+                Ok(Value::Null)
+            }
+            ProcessCommandBuiltin::Env => {
+                let key = self.eval_required_string(args.args[0], span)?;
+                let value = self.eval_expr(args.args[1])?;
+                let value = GlobalBuiltin::to_string(self.arena, &value);
+                let command = self.get_mutable_process_command(receiver, span, field)?;
+                command.set_env(key, value);
+                Ok(Value::Null)
+            }
+            ProcessCommandBuiltin::StdinText => {
+                let value = self.eval_expr(args.args[0])?;
+                let text = GlobalBuiltin::to_string(self.arena, &value);
+                let command = self.get_mutable_process_command(receiver, span, field)?;
+                command.set_stdin_text(text);
+                Ok(Value::Null)
+            }
+            ProcessCommandBuiltin::StdinInherit => {
+                let command = self.get_mutable_process_command(receiver, span, field)?;
+                command.set_stdin_policy(StdinPolicy::Inherit);
+                Ok(Value::Null)
+            }
+            ProcessCommandBuiltin::StdinNull => {
+                let command = self.get_mutable_process_command(receiver, span, field)?;
+                command.set_stdin_policy(StdinPolicy::Null);
+                Ok(Value::Null)
+            }
+            ProcessCommandBuiltin::StdoutCapture => {
+                let command = self.get_mutable_process_command(receiver, span, field)?;
+                command.set_stdout_policy(OutputPolicy::Capture);
+                Ok(Value::Null)
+            }
+            ProcessCommandBuiltin::StdoutInherit => {
+                let command = self.get_mutable_process_command(receiver, span, field)?;
+                command.set_stdout_policy(OutputPolicy::Inherit);
+                Ok(Value::Null)
+            }
+            ProcessCommandBuiltin::StdoutNull => {
+                let command = self.get_mutable_process_command(receiver, span, field)?;
+                command.set_stdout_policy(OutputPolicy::Null);
+                Ok(Value::Null)
+            }
+            ProcessCommandBuiltin::StderrCapture => {
+                let command = self.get_mutable_process_command(receiver, span, field)?;
+                command.set_stderr_policy(OutputPolicy::Capture);
+                Ok(Value::Null)
+            }
+            ProcessCommandBuiltin::StderrInherit => {
+                let command = self.get_mutable_process_command(receiver, span, field)?;
+                command.set_stderr_policy(OutputPolicy::Inherit);
+                Ok(Value::Null)
+            }
+            ProcessCommandBuiltin::StderrNull => {
+                let command = self.get_mutable_process_command(receiver, span, field)?;
+                command.set_stderr_policy(OutputPolicy::Null);
+                Ok(Value::Null)
+            }
+            ProcessCommandBuiltin::TimeoutMs => {
+                let timeout_ms = self.eval_timeout_ms(args.args[0], span)?;
+                let command = self.get_mutable_process_command(receiver, span, field)?;
+                command.set_timeout_ms(timeout_ms);
+                Ok(Value::Null)
+            }
+            ProcessCommandBuiltin::Run => {
+                unreachable!("run does not require mutable receiver")
+            }
+        }
+    }
+
     fn eval_array_member_call(
         &mut self,
         array: &Vec<Value<'a>, &'a Arena>,
@@ -917,6 +1119,49 @@ impl<'a> Runtime<'a> {
             ArrayBuiltin::Push | ArrayBuiltin::Pop | ArrayBuiltin::Reverse => {
                 unreachable!("Push, Pop, and Reverse require mutable receiver")
             }
+        }
+    }
+
+    fn eval_process_command_call(
+        &mut self,
+        command: &ProcessCommand<'a>,
+        builtin: ProcessCommandBuiltin,
+        _: &'a ArgList<'a>,
+        span: Span,
+    ) -> Result<Value<'a>, RuntimeError> {
+        match builtin {
+            ProcessCommandBuiltin::Run => {
+                if !self.host_policy.allow_process {
+                    return Err(RuntimeError::new(RuntimeErrorKind::ProcessDenied, span));
+                }
+
+                let spec = command
+                    .validate(&self.host_policy.process)
+                    .map_err(|err| RuntimeError::new(Self::map_process_error(err), span))?;
+                let result = sys::process::run(&spec, &self.host_policy.process, self.arena)
+                    .map_err(|err| RuntimeError::new(Self::map_process_error(err), span))?;
+                Ok(Value::Host(HostHandle::new_in(self.arena, HostValue::ProcessResult(result))))
+            }
+            _ => unreachable!("Only run is non-mutating for process_command"),
+        }
+    }
+
+    fn eval_process_result_call(
+        &self,
+        result: &ProcessResult<'a>,
+        builtin: ProcessResultBuiltin,
+    ) -> Value<'a> {
+        match builtin {
+            ProcessResultBuiltin::Success => Value::Bool(result.success),
+            ProcessResultBuiltin::ExitCode => {
+                result.exit_code.map_or(Value::Null, |code| Value::Number(f64::from(code)))
+            }
+            ProcessResultBuiltin::Stdout => result.stdout.as_ref().map_or(Value::Null, |stdout| {
+                Value::Str(ArenaCow::owned(ArenaString::from_str(self.frame, stdout.as_str())))
+            }),
+            ProcessResultBuiltin::Stderr => result.stderr.as_ref().map_or(Value::Null, |stderr| {
+                Value::Str(ArenaCow::owned(ArenaString::from_str(self.frame, stderr.as_str())))
+            }),
         }
     }
 
@@ -1072,6 +1317,145 @@ impl<'a> Runtime<'a> {
                 }
             }
             _ => Err(RuntimeError::new(RuntimeErrorKind::TypeMismatch, span)),
+        }
+    }
+
+    fn get_mutable_process_command(
+        &mut self,
+        object: ExprRef<'a>,
+        span: Span,
+        field: impl Into<String>,
+    ) -> Result<&mut ProcessCommand<'a>, RuntimeError> {
+        match object {
+            Expr::Var(name, ..) => {
+                let var = if let Some(local) = self.bound_expr_local(object) {
+                    self.lookup_local_mut(local)
+                } else {
+                    self.lookup_var_mut(name)
+                }
+                .expect("Semantic analysis guarantees variable exists");
+                match var {
+                    Value::Host(host) => match host.get_mut() {
+                        HostValue::ProcessCommand(command) => Ok(command),
+                        HostValue::ProcessResult(..) => Err(RuntimeError::new_with_extras(
+                            RuntimeErrorKind::TypeMismatch,
+                            span,
+                            field,
+                            "process_result",
+                        )),
+                    },
+                    _ => Err(RuntimeError::new_with_extras(
+                        RuntimeErrorKind::TypeMismatch,
+                        span,
+                        field,
+                        GlobalBuiltin::type_of(var),
+                    )),
+                }
+            }
+            Expr::Index { .. } => {
+                let (base_expr, base_var, index_exprs) = self.flatten_index_target(object);
+
+                let mut evaluated_indices = Vec::with_capacity_in(index_exprs.len(), self.frame);
+                for (index_expr, index_span) in &index_exprs {
+                    let idx = self.eval_index_value(index_expr, *index_span)?;
+                    evaluated_indices.push((idx, *index_span));
+                }
+
+                let mut slot = if let Some(local) = self.bound_expr_local(base_expr) {
+                    self.lookup_local_mut(local)
+                } else {
+                    self.lookup_var_mut(base_var)
+                }
+                .expect("Semantic analysis guarantees variable exists");
+
+                for (idx, index_span) in &evaluated_indices {
+                    match slot {
+                        Value::Array(items) => {
+                            if *idx >= items.len() {
+                                return Err(RuntimeError::new(
+                                    RuntimeErrorKind::IndexOutOfBounds,
+                                    *index_span,
+                                ));
+                            }
+                            slot = unsafe { items.get_unchecked_mut(*idx) };
+                        }
+                        _ => {
+                            return Err(RuntimeError::new(
+                                RuntimeErrorKind::InvalidIndex,
+                                *index_span,
+                            ));
+                        }
+                    }
+                }
+
+                match slot {
+                    Value::Host(host) => match host.get_mut() {
+                        HostValue::ProcessCommand(command) => Ok(command),
+                        HostValue::ProcessResult(..) => Err(RuntimeError::new_with_extras(
+                            RuntimeErrorKind::TypeMismatch,
+                            span,
+                            field,
+                            "process_result",
+                        )),
+                    },
+                    _ => Err(RuntimeError::new_with_extras(
+                        RuntimeErrorKind::TypeMismatch,
+                        span,
+                        field,
+                        GlobalBuiltin::type_of(slot),
+                    )),
+                }
+            }
+            _ => Err(RuntimeError::new(RuntimeErrorKind::TypeMismatch, span)),
+        }
+    }
+
+    fn eval_required_string(
+        &mut self,
+        expr: ExprRef<'a>,
+        span: Span,
+    ) -> Result<ArenaString<'a>, RuntimeError> {
+        let value = self.eval_expr(expr)?;
+        let Value::Str(text) = value else {
+            return Err(RuntimeError::new(RuntimeErrorKind::TypeMismatch, span));
+        };
+        Ok(ArenaString::from_str(self.arena, &text))
+    }
+
+    fn eval_timeout_ms(&mut self, expr: ExprRef<'a>, span: Span) -> Result<u32, RuntimeError> {
+        let value = self.eval_expr(expr)?;
+        let Value::Number(number) = value else {
+            return Err(RuntimeError::new(
+                RuntimeErrorKind::ProcessSpecInvalid("Timeout must be number"),
+                span,
+            ));
+        };
+        if !number.is_finite() || number <= 0.0 || number.fract() != 0.0 {
+            return Err(RuntimeError::new(
+                RuntimeErrorKind::ProcessSpecInvalid("Timeout must be positive whole number"),
+                span,
+            ));
+        }
+        #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+        Ok(number as u32)
+    }
+
+    fn map_process_error(err: ProcessError) -> RuntimeErrorKind {
+        match err {
+            ProcessError::Unsupported => RuntimeErrorKind::ProcessUnsupported,
+            ProcessError::Denied => RuntimeErrorKind::ProcessDenied,
+            ProcessError::SpawnFailed(err) => {
+                let msg: &'static str = Box::leak(err.to_string().into_boxed_str());
+                RuntimeErrorKind::ProcessSpawnFailed(msg)
+            }
+            ProcessError::Timeout => RuntimeErrorKind::ProcessTimeout,
+            ProcessError::OutputLimitExceeded(stream) => {
+                RuntimeErrorKind::ProcessOutputLimitExceeded(stream.as_str())
+            }
+            ProcessError::InvalidUtf8(stream) => {
+                RuntimeErrorKind::ProcessInvalidUtf8(stream.as_str())
+            }
+            ProcessError::SpecInvalid(msg) => RuntimeErrorKind::ProcessSpecInvalid(msg),
         }
     }
 

--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -432,14 +432,17 @@ impl<'src: 'ast, 'ast> Parser<'src, 'ast> {
                 }
             }
             _ => {
+                let span = self.cur.span;
                 self.emit_error(
-                    self.cur.span,
+                    span,
                     SyntaxError::ExpectedStatement,
-                    vec![Label {
-                        span: self.cur.span,
-                        message: ArenaCow::Borrowed("I dey expect statement"),
-                    }],
+                    vec![Label { span, message: ArenaCow::Borrowed("I dey expect statement") }],
                 );
+
+                // Error recovery must always make progress. A stray sync token like
+                // `)` would otherwise be re-parsed forever inside block bodies.
+                self.bump();
+                self.synchronize();
 
                 let expr = self.alloc(Expr::Null(Range::default()));
                 self.alloc(Stmt::Expression { expr, span: Range::default() })

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -2,6 +2,9 @@
 
 #![allow(non_camel_case_types)]
 
+#[cfg(not(target_family = "wasm"))]
+mod process_common;
+
 #[cfg(windows)]
 mod windows;
 
@@ -22,6 +25,7 @@ use wasm::*;
 pub use windows::*;
 
 use crate::arena::{Arena, ArenaString};
+use crate::process::{ProcessCaps, ProcessError, ProcessResult, ProcessSpec};
 use crate::runtime::Value;
 
 #[cfg(unix)]
@@ -37,6 +41,13 @@ pub type stdin = UnixStdin;
 pub type stdin = WindowsStdin;
 #[cfg(target_family = "wasm")]
 pub type stdin = WasmStdin;
+
+#[cfg(unix)]
+pub type process = unix::UnixProcessRunner;
+#[cfg(windows)]
+pub type process = windows::WindowsProcessRunner;
+#[cfg(target_family = "wasm")]
+pub type process = wasm::WasmProcessRunner;
 
 pub trait VirtualMemory {
     /// Reserves a virtual memory region of the given size.
@@ -83,4 +94,12 @@ pub trait Stdin {
     /// Unlike the `read_line` from [`std::io::stdin`] that's hardcoded to [`std::string::String`] type, this
     /// one allocates with [`ArenaString`].
     fn read_line<'a>(prompt: &Value<'a>, arena: &'a Arena) -> Result<ArenaString<'a>, io::Error>;
+}
+
+pub trait ProcessRunner {
+    fn run<'arena>(
+        spec: &ProcessSpec<'_>,
+        caps: &ProcessCaps,
+        arena: &'arena Arena,
+    ) -> Result<ProcessResult<'arena>, ProcessError>;
 }

--- a/src/sys/process_common.rs
+++ b/src/sys/process_common.rs
@@ -1,0 +1,240 @@
+use std::io::{self, Read, Write};
+use std::process::{Child, Command, Stdio};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use crate::arena::{Arena, ArenaString};
+use crate::process::{
+    OutputPolicy, ProcessCaps, ProcessError, ProcessResult, ProcessSpec, ProcessStream, StdinPolicy,
+};
+
+pub fn run_host_process<'arena>(
+    spec: &ProcessSpec<'_>,
+    caps: &ProcessCaps,
+    arena: &'arena Arena,
+) -> Result<ProcessResult<'arena>, ProcessError> {
+    let mut command = Command::new(spec.program);
+    command.args(spec.args.iter().map(ArenaString::as_str));
+    if let Some(cwd) = spec.cwd {
+        command.current_dir(cwd);
+    }
+    for pair in spec.env {
+        command.env(pair.key.as_str(), pair.value.as_str());
+    }
+
+    configure_stdio(&mut command, spec);
+
+    let mut child = command.spawn().map_err(ProcessError::SpawnFailed)?;
+    let overflow = Arc::new(AtomicU8::new(0));
+
+    let writer = spawn_stdin_writer(&mut child, spec.stdin);
+    let stdout = spawn_capture_reader(
+        &mut child,
+        spec.stdout,
+        caps.max_capture_bytes_per_stream,
+        ProcessStream::Stdout,
+        Arc::clone(&overflow),
+    );
+    let stderr = spawn_capture_reader(
+        &mut child,
+        spec.stderr,
+        caps.max_capture_bytes_per_stream,
+        ProcessStream::Stderr,
+        Arc::clone(&overflow),
+    );
+
+    let status = match wait_for_child(&mut child, caps.wait_poll_ms, spec.timeout_ms, &overflow) {
+        Ok(status) => status,
+        Err(err) => {
+            let _ = join_writer(writer);
+            let _ = join_capture(stdout, ProcessStream::Stdout, &overflow, arena);
+            let _ = join_capture(stderr, ProcessStream::Stderr, &overflow, arena);
+            return Err(err);
+        }
+    };
+
+    let writer_result = join_writer(writer);
+    if let Err(err) = writer_result {
+        return Err(ProcessError::SpawnFailed(err));
+    }
+
+    let stdout = join_capture(stdout, ProcessStream::Stdout, &overflow, arena)?;
+    let stderr = join_capture(stderr, ProcessStream::Stderr, &overflow, arena)?;
+
+    Ok(ProcessResult {
+        success: status.code() == Some(0),
+        exit_code: status.code(),
+        stdout,
+        stderr,
+    })
+}
+
+fn configure_stdio(command: &mut Command, spec: &ProcessSpec<'_>) {
+    command.stdin(match spec.stdin {
+        StdinPolicy::Inherit => Stdio::inherit(),
+        StdinPolicy::Null => Stdio::null(),
+        StdinPolicy::Text(..) => Stdio::piped(),
+    });
+    command.stdout(output_stdio(spec.stdout));
+    command.stderr(output_stdio(spec.stderr));
+}
+
+fn output_stdio(policy: OutputPolicy) -> Stdio {
+    match policy {
+        OutputPolicy::Inherit => Stdio::inherit(),
+        OutputPolicy::Null => Stdio::null(),
+        OutputPolicy::Capture => Stdio::piped(),
+    }
+}
+
+fn spawn_stdin_writer(
+    child: &mut Child,
+    stdin: &StdinPolicy<'_>,
+) -> Option<JoinHandle<io::Result<()>>> {
+    let StdinPolicy::Text(text) = stdin else {
+        return None;
+    };
+    let mut child_stdin = child.stdin.take()?;
+    let input = text.as_bytes().to_vec();
+    Some(thread::spawn(move || {
+        if input.is_empty() {
+            return Ok(());
+        }
+        match child_stdin.write_all(&input) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == io::ErrorKind::BrokenPipe => Ok(()),
+            Err(err) => Err(err),
+        }
+    }))
+}
+
+fn spawn_capture_reader(
+    child: &mut Child,
+    policy: OutputPolicy,
+    cap: u32,
+    stream: ProcessStream,
+    overflow: Arc<AtomicU8>,
+) -> Option<JoinHandle<io::Result<std::vec::Vec<u8>>>> {
+    if policy != OutputPolicy::Capture {
+        return None;
+    }
+
+    let reader = match stream {
+        ProcessStream::Stdout => child.stdout.take().map(StreamReader::Stdout),
+        ProcessStream::Stderr => child.stderr.take().map(StreamReader::Stderr),
+    }?;
+
+    Some(thread::spawn(move || match reader {
+        StreamReader::Stdout(stdout) => read_captured_stream(stdout, cap, 1, &overflow),
+        StreamReader::Stderr(stderr) => read_captured_stream(stderr, cap, 2, &overflow),
+    }))
+}
+
+enum StreamReader {
+    Stdout(std::process::ChildStdout),
+    Stderr(std::process::ChildStderr),
+}
+
+fn read_captured_stream<R: Read>(
+    mut reader: R,
+    cap: u32,
+    overflow_code: u8,
+    overflow: &Arc<AtomicU8>,
+) -> io::Result<std::vec::Vec<u8>> {
+    let mut buf = std::vec::Vec::with_capacity((cap.min(8_192)) as usize);
+    let mut chunk = [0u8; 8_192];
+    let max = cap as usize;
+
+    loop {
+        let n = reader.read(&mut chunk)?;
+        if n == 0 {
+            break;
+        }
+        if buf.len().saturating_add(n) > max {
+            let _ = overflow.compare_exchange(0, overflow_code, Ordering::SeqCst, Ordering::SeqCst);
+            break;
+        }
+        buf.extend_from_slice(&chunk[..n]);
+    }
+
+    Ok(buf)
+}
+
+fn wait_for_child(
+    child: &mut Child,
+    wait_poll_ms: u32,
+    timeout_ms: u32,
+    overflow: &AtomicU8,
+) -> Result<std::process::ExitStatus, ProcessError> {
+    let start = Instant::now();
+    let sleep_for = Duration::from_millis(u64::from(wait_poll_ms.max(1)));
+    let timeout = Duration::from_millis(u64::from(timeout_ms));
+
+    loop {
+        let overflow_code = overflow.load(Ordering::Acquire);
+        if overflow_code != 0 {
+            terminate_child(child);
+            return Err(ProcessError::OutputLimitExceeded(stream_from_code(overflow_code)));
+        }
+
+        if let Some(status) = child.try_wait().map_err(ProcessError::SpawnFailed)? {
+            return Ok(status);
+        }
+        if start.elapsed() >= timeout {
+            terminate_child(child);
+            return Err(ProcessError::Timeout);
+        }
+        thread::sleep(sleep_for);
+    }
+}
+
+fn terminate_child(child: &mut Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+fn join_writer(writer: Option<JoinHandle<io::Result<()>>>) -> io::Result<()> {
+    match writer {
+        Some(handle) => handle.join().expect("stdin writer thread should not panic"),
+        None => Ok(()),
+    }
+}
+
+fn join_capture<'arena>(
+    reader: Option<JoinHandle<io::Result<std::vec::Vec<u8>>>>,
+    stream: ProcessStream,
+    overflow: &AtomicU8,
+    arena: &'arena Arena,
+) -> Result<Option<ArenaString<'arena>>, ProcessError> {
+    let Some(handle) = reader else {
+        return Ok(None);
+    };
+
+    let bytes = handle
+        .join()
+        .expect("capture reader thread should not panic")
+        .map_err(ProcessError::SpawnFailed)?;
+
+    if overflow.load(Ordering::Acquire) == stream_code(stream) {
+        return Err(ProcessError::OutputLimitExceeded(stream));
+    }
+
+    let text = String::from_utf8(bytes).map_err(|_| ProcessError::InvalidUtf8(stream))?;
+    Ok(Some(ArenaString::from_str(arena, &text)))
+}
+
+const fn stream_code(stream: ProcessStream) -> u8 {
+    match stream {
+        ProcessStream::Stdout => 1,
+        ProcessStream::Stderr => 2,
+    }
+}
+
+const fn stream_from_code(code: u8) -> ProcessStream {
+    match code {
+        1 => ProcessStream::Stdout,
+        _ => ProcessStream::Stderr,
+    }
+}

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -9,9 +9,10 @@ use std::slice;
 
 use memchr_rs::memchr;
 
-use super::{Stdin, VirtualMemory};
+use super::{ProcessRunner, Stdin, VirtualMemory, process_common};
 use crate::arena::{Arena, ArenaString};
 use crate::helpers::KIBI;
+use crate::process::{ProcessCaps, ProcessError, ProcessResult, ProcessSpec};
 use crate::runtime::Value;
 
 #[cfg(target_os = "netbsd")]
@@ -122,5 +123,17 @@ impl Stdin for UnixStdin {
         }
 
         Ok(buf)
+    }
+}
+
+pub struct UnixProcessRunner;
+
+impl ProcessRunner for UnixProcessRunner {
+    fn run<'arena>(
+        spec: &ProcessSpec<'_>,
+        caps: &ProcessCaps,
+        arena: &'arena Arena,
+    ) -> Result<ProcessResult<'arena>, ProcessError> {
+        process_common::run_host_process(spec, caps, arena)
     }
 }

--- a/src/sys/wasm.rs
+++ b/src/sys/wasm.rs
@@ -2,8 +2,9 @@ use std::alloc::{Layout, alloc, dealloc};
 use std::ptr::NonNull;
 use std::{io, mem};
 
-use super::{Stdin, VirtualMemory};
+use super::{ProcessRunner, Stdin, VirtualMemory};
 use crate::arena::{Arena, ArenaString};
+use crate::process::{ProcessCaps, ProcessError, ProcessResult, ProcessSpec};
 use crate::runtime::Value;
 
 pub struct WasmVirtualMemory;
@@ -15,11 +16,11 @@ impl VirtualMemory for WasmVirtualMemory {
         NonNull::new(unsafe { alloc(layout) }).ok_or(u32::MAX)
     }
 
-    unsafe fn commit(_base: NonNull<u8>, _size: usize) -> Result<(), u32> {
+    unsafe fn commit(_: NonNull<u8>, _: usize) -> Result<(), u32> {
         Ok(())
     }
 
-    unsafe fn decommit(_base: NonNull<u8>, _size: usize) {}
+    unsafe fn decommit(_: NonNull<u8>, _: usize) {}
 
     unsafe fn release(base: NonNull<u8>, size: usize) {
         if let Ok(layout) = Layout::from_size_align(size, mem::align_of::<usize>()) {
@@ -31,7 +32,19 @@ impl VirtualMemory for WasmVirtualMemory {
 pub struct WasmStdin;
 
 impl Stdin for WasmStdin {
-    fn read_line<'a>(_prompt: &Value<'a>, _arena: &'a Arena) -> Result<ArenaString<'a>, io::Error> {
+    fn read_line<'a>(_: &Value<'a>, _: &'a Arena) -> Result<ArenaString<'a>, io::Error> {
         Err(io::Error::new(io::ErrorKind::Unsupported, "Dis platform lack I/O support"))
+    }
+}
+
+pub struct WasmProcessRunner;
+
+impl ProcessRunner for WasmProcessRunner {
+    fn run<'arena>(
+        _: &ProcessSpec<'_>,
+        _: &ProcessCaps,
+        _: &'arena Arena,
+    ) -> Result<ProcessResult<'arena>, ProcessError> {
+        Err(ProcessError::Unsupported)
     }
 }

--- a/src/sys/windows.rs
+++ b/src/sys/windows.rs
@@ -10,9 +10,10 @@ use windows_sys::Win32::System::Console::{
 };
 use windows_sys::Win32::System::Memory;
 
-use super::{Stdin, VirtualMemory};
+use super::{ProcessRunner, Stdin, VirtualMemory, process_common};
 use crate::arena::{Arena, ArenaString};
 use crate::helpers::KIBI;
+use crate::process::{ProcessCaps, ProcessError, ProcessResult, ProcessSpec};
 use crate::runtime::Value;
 
 pub struct WindowsVirtualMemory;
@@ -87,6 +88,18 @@ impl Stdin for WindowsStdin {
         io::stdout().flush()?;
 
         if is_console() { read_line_console(arena) } else { read_line_pipe(arena) }
+    }
+}
+
+pub struct WindowsProcessRunner;
+
+impl ProcessRunner for WindowsProcessRunner {
+    fn run<'arena>(
+        spec: &ProcessSpec<'_>,
+        caps: &ProcessCaps,
+        arena: &'arena Arena,
+    ) -> Result<ProcessResult<'arena>, ProcessError> {
+        process_common::run_host_process(spec, caps, arena)
     }
 }
 

--- a/tests/analysis.rs
+++ b/tests/analysis.rs
@@ -4,6 +4,7 @@ use naijascript::analysis::cfg::{
 use naijascript::analysis::diagnostics::{
     compute_function_reachability, unused_functions, unused_variables,
 };
+use naijascript::analysis::effects::ExprClass;
 use naijascript::analysis::facts::ProgramFacts;
 use naijascript::analysis::ids::{BlockId, FunctionId, LocalId, StmtId};
 use naijascript::analysis::limits::{AnalysisCaps, DEFAULT_CAPS, first_exceeded_limit};
@@ -711,5 +712,72 @@ fn optimization_plan_marks_unreachable_statements_and_unused_function_defs_remov
         }));
         assert_eq!(unused_functions.len(), 1);
         assert_eq!(plan.removable_function_defs.len(), 1);
+    });
+}
+
+#[test]
+fn process_command_and_run_have_expected_effect_classes() {
+    let src = r#"
+        make cmd get command("echo")
+        cmd.run()
+    "#;
+    with_pipeline(src, |_, (root, parse_errors), resolver, _| {
+        assert!(parse_errors.diagnostics.is_empty());
+        resolver.resolve(root);
+        assert!(!resolver.errors.has_errors(), "{:?}", resolver.errors.diagnostics);
+
+        let facts = &resolver.facts;
+        let build_stmt =
+            facts.stmt_id(root.stmts[0]).expect("command assignment should have a statement id");
+        let run_stmt = facts.stmt_id(root.stmts[1]).expect("run call should have a statement id");
+
+        assert_eq!(facts.stmt_effect(build_stmt).expr_class, ExprClass::PureNoTrap);
+        assert_eq!(facts.stmt_effect(run_stmt).expr_class, ExprClass::Impure);
+    });
+}
+
+#[test]
+fn process_builder_mutation_stays_non_removable() {
+    let src = r#"
+        make cmd get command("echo")
+        cmd.arg("hello")
+    "#;
+    with_pipeline(src, |arena, (root, parse_errors), resolver, _| {
+        assert!(parse_errors.diagnostics.is_empty());
+        resolver.resolve(root);
+        assert!(!resolver.errors.has_errors(), "{:?}", resolver.errors.diagnostics);
+
+        let facts = &resolver.facts;
+        let program = build_program(facts, arena);
+        let reachable = reachable_statement_mask(&program, arena);
+        let summaries = compute_summaries(facts, arena);
+        let function_reachability =
+            compute_function_reachability(&program, facts, &reachable, arena);
+        let unused_assignments = unused_assignments(&program, facts, &summaries, &reachable, arena);
+        let unused_variables = unused_variables(
+            &program,
+            facts,
+            &summaries,
+            &reachable,
+            &function_reachability,
+            arena,
+        );
+        let unused_functions = unused_functions(facts, &reachable, &function_reachability, arena);
+        let plan = build_optimization_plan(
+            OptimizationInputs {
+                program: &program,
+                facts,
+                summaries: &summaries,
+                reachable: &reachable,
+                unused_assignments: &unused_assignments,
+                unused_variables: &unused_variables,
+                unused_functions: &unused_functions,
+            },
+            arena,
+        );
+
+        let mutation_stmt =
+            facts.stmt_id(root.stmts[1]).expect("builder mutation should have a statement id");
+        assert!(!plan.removable_stmts.contains(&mutation_stmt));
     });
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,8 +1,15 @@
 #![allow(clippy::missing_panics_doc, unused)]
 
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::OnceLock;
+
 use naijascript::arena::Arena;
 use naijascript::diagnostics::Diagnostics;
 use naijascript::helpers::MEBI;
+use naijascript::process::HostPolicy;
 use naijascript::resolver::Resolver;
 use naijascript::runtime::Runtime;
 use naijascript::syntax::parser::{BlockRef, Parser};
@@ -50,4 +57,54 @@ where
     let mut runtime = Runtime::new(&arena, Some(&frame));
 
     f(&arena, (root, parse_errors), &mut resolver, &mut runtime)
+}
+
+pub fn with_pipeline_and_host_policy<F, R>(src: &str, host_policy: HostPolicy, f: F) -> R
+where
+    for<'a> F: FnOnce(
+        &'a Arena,
+        (BlockRef<'a>, &'a Diagnostics),
+        &mut Resolver<'a, 'a>,
+        &mut Runtime<'a>,
+    ) -> R,
+{
+    let arena = Arena::new(4 * MEBI).unwrap();
+    let frame = Arena::new(2 * MEBI).unwrap();
+
+    let lexer = Lexer::new(src, &arena);
+    let mut parser = Parser::new(lexer, &arena);
+    let (root, parse_errors) = parser.parse_program();
+    let mut resolver = Resolver::new(&arena);
+    let mut runtime = Runtime::new_with_host_policy(&arena, Some(&frame), host_policy);
+
+    f(&arena, (root, parse_errors), &mut resolver, &mut runtime)
+}
+
+pub fn process_helper_path() -> &'static Path {
+    static HELPER_PATH: OnceLock<PathBuf> = OnceLock::new();
+    HELPER_PATH.get_or_init(compile_process_helper).as_path()
+}
+
+fn compile_process_helper() -> PathBuf {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let source = manifest_dir.join("tests/fixtures/process_helper.rs");
+    let out_dir = manifest_dir.join("target/process-test-helper");
+    fs::create_dir_all(&out_dir).expect("process helper output directory should be creatable");
+
+    let helper_name = if cfg!(windows) { "process_helper.exe" } else { "process_helper" };
+    let output = out_dir.join(helper_name);
+    let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| OsString::from("rustc"));
+
+    // The helper stays out of Cargo's production binary surface and is compiled
+    // only when the process integration tests need it.
+    let status = Command::new(rustc)
+        .arg("--edition=2024")
+        .arg(&source)
+        .arg("-o")
+        .arg(&output)
+        .status()
+        .expect("rustc should compile the process helper fixture");
+    assert!(status.success(), "process helper fixture compilation should succeed");
+
+    output
 }

--- a/tests/fixtures/process_helper.rs
+++ b/tests/fixtures/process_helper.rs
@@ -1,0 +1,140 @@
+use std::io::{self, Read, Write};
+use std::process::ExitCode;
+use std::time::Duration;
+use std::{env, thread};
+
+fn usage() -> ExitCode {
+    eprintln!(
+        "usage: process_helper <command> [args...]
+commands:
+  exit <code>
+  echo-stdout <text>
+  echo-stderr <text>
+  echo-both <stdout> <stderr>
+  cat-stdin
+  print-env <key>
+  print-cwd
+  print-args <arg>...
+  sleep-ms <ms>
+  emit-bytes <hex>"
+    );
+    ExitCode::from(64)
+}
+
+fn parse_u8_hex(hex: &str) -> Result<Vec<u8>, ()> {
+    if !hex.len().is_multiple_of(2) {
+        return Err(());
+    }
+
+    let mut out = Vec::with_capacity(hex.len() / 2);
+    let bytes = hex.as_bytes();
+    let mut idx = 0;
+    while idx < bytes.len() {
+        let hi = (bytes[idx] as char).to_digit(16).ok_or(())?;
+        let lo = (bytes[idx + 1] as char).to_digit(16).ok_or(())?;
+        let byte = u8::try_from((hi << 4) | lo).map_err(|_| ())?;
+        out.push(byte);
+        idx += 2;
+    }
+    Ok(out)
+}
+
+fn main() -> ExitCode {
+    let mut args = env::args();
+    let _program = args.next();
+    let Some(command) = args.next() else {
+        return usage();
+    };
+
+    match command.as_str() {
+        "exit" => {
+            let Some(code) = args.next() else {
+                return usage();
+            };
+            let Ok(code) = code.parse::<u8>() else {
+                return usage();
+            };
+            ExitCode::from(code)
+        }
+        "echo-stdout" => {
+            let Some(text) = args.next() else {
+                return usage();
+            };
+            print!("{text}");
+            ExitCode::SUCCESS
+        }
+        "echo-stderr" => {
+            let Some(text) = args.next() else {
+                return usage();
+            };
+            eprint!("{text}");
+            ExitCode::SUCCESS
+        }
+        "echo-both" => {
+            let (Some(stdout), Some(stderr)) = (args.next(), args.next()) else {
+                return usage();
+            };
+            print!("{stdout}");
+            eprint!("{stderr}");
+            ExitCode::SUCCESS
+        }
+        "cat-stdin" => {
+            let mut input = String::new();
+            if io::stdin().read_to_string(&mut input).is_err() {
+                return ExitCode::from(1);
+            }
+            print!("{input}");
+            ExitCode::SUCCESS
+        }
+        "print-env" => {
+            let Some(key) = args.next() else {
+                return usage();
+            };
+            if let Ok(value) = env::var(&key) {
+                print!("{value}");
+            }
+            ExitCode::SUCCESS
+        }
+        "print-cwd" => {
+            let Ok(cwd) = env::current_dir() else {
+                return ExitCode::from(1);
+            };
+            print!("{}", cwd.display());
+            ExitCode::SUCCESS
+        }
+        "print-args" => {
+            let mut first = true;
+            for arg in args {
+                if !first {
+                    println!();
+                }
+                first = false;
+                print!("{arg}");
+            }
+            ExitCode::SUCCESS
+        }
+        "sleep-ms" => {
+            let Some(ms) = args.next() else {
+                return usage();
+            };
+            let Ok(ms) = ms.parse::<u64>() else {
+                return usage();
+            };
+            thread::sleep(Duration::from_millis(ms));
+            ExitCode::SUCCESS
+        }
+        "emit-bytes" => {
+            let Some(hex) = args.next() else {
+                return usage();
+            };
+            let Ok(bytes) = parse_u8_hex(&hex) else {
+                return usage();
+            };
+            if io::stdout().write_all(&bytes).is_err() {
+                return ExitCode::from(1);
+            }
+            ExitCode::SUCCESS
+        }
+        _ => usage(),
+    }
+}

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -178,6 +178,17 @@ fn test_parse_loop_missing_end() {
 }
 
 #[test]
+fn test_parse_block_error_recovers_after_stray_token() {
+    let src = r#"
+        if to say (true) start
+            make
+            shout("ok")
+        end
+    "#;
+    assert_parse!(src, SyntaxError::ExpectedStatement);
+}
+
+#[test]
 fn test_parse_trailing_tokens() {
     let src = "make x get 5 123";
     assert_parse!(src, SyntaxError::TrailingTokensAfterProgramEnd);

--- a/tests/process.rs
+++ b/tests/process.rs
@@ -1,0 +1,461 @@
+#![feature(allocator_api)]
+
+use naijascript::arena::ArenaCow;
+use naijascript::diagnostics::AsStr;
+use naijascript::process::HostPolicy;
+use naijascript::runtime::{RuntimeErrorKind, Value};
+
+mod common;
+use common::{process_helper_path, with_pipeline, with_pipeline_and_host_policy};
+
+fn helper_path() -> &'static str {
+    process_helper_path()
+        .to_str()
+        .expect("process helper path should be valid UTF-8 for NaijaScript string literals")
+}
+
+fn helper_dir() -> String {
+    process_helper_path()
+        .parent()
+        .expect("helper binary should have a parent directory")
+        .display()
+        .to_string()
+}
+
+fn ns_string_literal(text: &str) -> String {
+    let mut quoted = String::with_capacity(text.len() + 2);
+    quoted.push('"');
+    for ch in text.chars() {
+        match ch {
+            '\\' => quoted.push_str("\\\\"),
+            '"' => quoted.push_str("\\\""),
+            '\n' => quoted.push_str("\\n"),
+            '\r' => quoted.push_str("\\r"),
+            '\t' => quoted.push_str("\\t"),
+            _ => quoted.push(ch),
+        }
+    }
+    quoted.push('"');
+    quoted
+}
+
+macro_rules! assert_process_output {
+    ($src:expr, $expected:expr) => {{
+        with_pipeline($src, |_, (root, parse_errors), resolver, runtime| {
+            assert!(parse_errors.diagnostics.is_empty(), "{:?}", parse_errors.diagnostics);
+            resolver.resolve(root);
+            assert!(!resolver.errors.has_errors(), "{:?}", resolver.errors.diagnostics);
+            runtime.run_with_analysis(root, &resolver.facts, resolver.optimization_plan.as_ref());
+            assert!(!runtime.errors.has_errors(), "{:?}", runtime.errors.diagnostics);
+            assert_eq!(runtime.output, $expected);
+        })
+    }};
+    ($src:expr, $expected:expr, policy: $policy:expr) => {{
+        with_pipeline_and_host_policy(
+            $src,
+            $policy,
+            |_, (root, parse_errors), resolver, runtime| {
+                assert!(parse_errors.diagnostics.is_empty(), "{:?}", parse_errors.diagnostics);
+                resolver.resolve(root);
+                assert!(!resolver.errors.has_errors(), "{:?}", resolver.errors.diagnostics);
+                runtime.run_with_analysis(
+                    root,
+                    &resolver.facts,
+                    resolver.optimization_plan.as_ref(),
+                );
+                assert!(!runtime.errors.has_errors(), "{:?}", runtime.errors.diagnostics);
+                assert_eq!(runtime.output, $expected);
+            },
+        )
+    }};
+}
+
+macro_rules! assert_process_error {
+    ($src:expr, $expected:expr) => {{
+        with_pipeline($src, |_, (root, parse_errors), resolver, runtime| {
+            assert!(parse_errors.diagnostics.is_empty(), "{:?}", parse_errors.diagnostics);
+            resolver.resolve(root);
+            assert!(!resolver.errors.has_errors(), "{:?}", resolver.errors.diagnostics);
+            runtime.run_with_analysis(root, &resolver.facts, resolver.optimization_plan.as_ref());
+            assert!(
+                runtime.errors.diagnostics.iter().any(|diag| diag.message == $expected.as_str()),
+                "Expected runtime error {}, got {:?}",
+                $expected.as_str(),
+                runtime.errors.diagnostics
+            );
+        })
+    }};
+    ($src:expr, $expected:expr, policy: $policy:expr) => {{
+        with_pipeline_and_host_policy(
+            $src,
+            $policy,
+            |_, (root, parse_errors), resolver, runtime| {
+                assert!(parse_errors.diagnostics.is_empty(), "{:?}", parse_errors.diagnostics);
+                resolver.resolve(root);
+                assert!(!resolver.errors.has_errors(), "{:?}", resolver.errors.diagnostics);
+                runtime.run_with_analysis(
+                    root,
+                    &resolver.facts,
+                    resolver.optimization_plan.as_ref(),
+                );
+                assert!(
+                    runtime
+                        .errors
+                        .diagnostics
+                        .iter()
+                        .any(|diag| diag.message == $expected.as_str()),
+                    "Expected runtime error {}, got {:?}",
+                    $expected.as_str(),
+                    runtime.errors.diagnostics
+                );
+            },
+        )
+    }};
+}
+
+#[test]
+fn direct_execution_reports_types_and_captured_output() {
+    let helper = ns_string_literal(helper_path());
+    let src = format!(
+        r#"
+        make cmd get command({helper})
+        cmd.arg("echo-stdout")
+        cmd.arg("hello")
+        cmd.stdout_capture()
+        make res get cmd.run()
+        shout(typeof(cmd))
+        shout(typeof(res))
+        shout(res.success())
+        shout(res.exit_code())
+        shout(res.stdout())
+        shout(res.stderr())
+        "#
+    );
+
+    assert_process_output!(
+        &src,
+        vec![
+            Value::Str(ArenaCow::borrowed("process_command")),
+            Value::Str(ArenaCow::borrowed("process_result")),
+            Value::Bool(true),
+            Value::Number(0.0),
+            Value::Str(ArenaCow::borrowed("hello")),
+            Value::Null,
+        ]
+    );
+}
+
+#[test]
+fn non_zero_exit_is_result_data() {
+    let helper = ns_string_literal(helper_path());
+    let src = format!(
+        r#"
+        make cmd get command({helper})
+        cmd.arg("exit")
+        cmd.arg("7")
+        make res get cmd.run()
+        shout(res.success())
+        shout(res.exit_code())
+        "#
+    );
+
+    assert_process_output!(&src, vec![Value::Bool(false), Value::Number(7.0)]);
+}
+
+#[test]
+fn path_lookup_uses_env_override() {
+    let dir = ns_string_literal(&helper_dir());
+    let src = format!(
+        r#"
+        make cmd get command("process_helper")
+        cmd.arg("echo-stdout")
+        cmd.arg("from_path")
+        cmd.env("PATH", {dir})
+        cmd.stdout_capture()
+        make res get cmd.run()
+        shout(res.stdout())
+        "#
+    );
+
+    assert_process_output!(&src, vec![Value::Str(ArenaCow::borrowed("from_path"))]);
+}
+
+#[test]
+fn argument_boundaries_are_preserved() {
+    let helper = ns_string_literal(helper_path());
+    let src = format!(
+        r#"
+        make cmd get command({helper})
+        cmd.arg("print-args")
+        cmd.arg("hello world")
+        cmd.arg("*literal*")
+        cmd.arg("quote \" mark")
+        cmd.stdout_capture()
+        make res get cmd.run()
+        shout(res.stdout())
+        "#
+    );
+
+    assert_process_output!(
+        &src,
+        vec![Value::Str(ArenaCow::borrowed("hello world\n*literal*\nquote \" mark"))]
+    );
+}
+
+#[test]
+fn cwd_override_is_observed() {
+    let helper = ns_string_literal(helper_path());
+    let expected_cwd =
+        std::env::current_dir().expect("current directory should exist").display().to_string();
+    let cwd = ns_string_literal(&expected_cwd);
+    let src = format!(
+        r#"
+        make cmd get command({helper})
+        cmd.arg("print-cwd")
+        cmd.cwd({cwd})
+        cmd.stdout_capture()
+        make res get cmd.run()
+        shout(res.stdout())
+        "#
+    );
+    with_pipeline(&src, |_, (root, parse_errors), resolver, runtime| {
+        assert!(parse_errors.diagnostics.is_empty(), "{:?}", parse_errors.diagnostics);
+        resolver.resolve(root);
+        assert!(!resolver.errors.has_errors(), "{:?}", resolver.errors.diagnostics);
+        runtime.run_with_analysis(root, &resolver.facts, resolver.optimization_plan.as_ref());
+        assert!(!runtime.errors.has_errors(), "{:?}", runtime.errors.diagnostics);
+        assert_eq!(
+            runtime.output,
+            vec![Value::Str(ArenaCow::owned(naijascript::arena::ArenaString::from_str(
+                runtime.output.allocator(),
+                &expected_cwd
+            )))]
+        );
+    });
+}
+
+#[test]
+fn env_override_is_observed() {
+    let helper = ns_string_literal(helper_path());
+    let src = format!(
+        r#"
+        make cmd get command({helper})
+        cmd.arg("print-env")
+        cmd.arg("NAIJA_TEST_VALUE")
+        cmd.env("NAIJA_TEST_VALUE", "from_env")
+        cmd.stdout_capture()
+        make res get cmd.run()
+        shout(res.stdout())
+        "#
+    );
+
+    assert_process_output!(&src, vec![Value::Str(ArenaCow::borrowed("from_env"))]);
+}
+
+#[test]
+fn stdin_text_round_trips() {
+    let helper = ns_string_literal(helper_path());
+    let src = format!(
+        r#"
+        make cmd get command({helper})
+        cmd.arg("cat-stdin")
+        cmd.stdin_text("b\na\n")
+        cmd.stdout_capture()
+        make res get cmd.run()
+        shout(res.stdout())
+        "#
+    );
+
+    assert_process_output!(&src, vec![Value::Str(ArenaCow::borrowed("b\na\n"))]);
+}
+
+#[test]
+fn stdin_null_produces_empty_capture() {
+    let helper = ns_string_literal(helper_path());
+    let src = format!(
+        r#"
+        make cmd get command({helper})
+        cmd.arg("cat-stdin")
+        cmd.stdin_null()
+        cmd.stdout_capture()
+        make res get cmd.run()
+        shout(res.stdout())
+        "#
+    );
+
+    assert_process_output!(&src, vec![Value::Str(ArenaCow::borrowed(""))]);
+}
+
+#[test]
+fn captures_stdout_and_stderr_independently() {
+    let helper = ns_string_literal(helper_path());
+    let src = format!(
+        r#"
+        make cmd get command({helper})
+        cmd.arg("echo-both")
+        cmd.arg("out")
+        cmd.arg("err")
+        cmd.stdout_capture()
+        cmd.stderr_capture()
+        make res get cmd.run()
+        shout(res.stdout())
+        shout(res.stderr())
+        "#
+    );
+
+    assert_process_output!(
+        &src,
+        vec![Value::Str(ArenaCow::borrowed("out")), Value::Str(ArenaCow::borrowed("err")),]
+    );
+}
+
+#[test]
+fn stdout_inherit_clears_capture_and_leaves_stderr_capture_intact() {
+    let helper = ns_string_literal(helper_path());
+    let src = format!(
+        r#"
+        make cmd get command({helper})
+        cmd.arg("echo-both")
+        cmd.arg("inherit_out")
+        cmd.arg("captured_err")
+        cmd.stdout_capture()
+        cmd.stdout_inherit()
+        cmd.stderr_capture()
+        make res get cmd.run()
+        shout(res.stdout())
+        shout(res.stderr())
+        "#
+    );
+
+    assert_process_output!(&src, vec![Value::Null, Value::Str(ArenaCow::borrowed("captured_err"))]);
+}
+
+#[test]
+fn stdout_null_clears_capture_and_drops_stdout() {
+    let helper = ns_string_literal(helper_path());
+    let src = format!(
+        r#"
+        make cmd get command({helper})
+        cmd.arg("echo-both")
+        cmd.arg("dropped_out")
+        cmd.arg("captured_err")
+        cmd.stdout_capture()
+        cmd.stdout_null()
+        cmd.stderr_capture()
+        make res get cmd.run()
+        shout(res.stdout())
+        shout(res.stderr())
+        "#
+    );
+
+    assert_process_output!(&src, vec![Value::Null, Value::Str(ArenaCow::borrowed("captured_err"))]);
+}
+
+#[test]
+fn stderr_inherit_clears_capture_and_leaves_stdout_capture_intact() {
+    let helper = ns_string_literal(helper_path());
+    let src = format!(
+        r#"
+        make cmd get command({helper})
+        cmd.arg("echo-both")
+        cmd.arg("captured_out")
+        cmd.arg("inherit_err")
+        cmd.stdout_capture()
+        cmd.stderr_capture()
+        cmd.stderr_inherit()
+        make res get cmd.run()
+        shout(res.stdout())
+        shout(res.stderr())
+        "#
+    );
+
+    assert_process_output!(&src, vec![Value::Str(ArenaCow::borrowed("captured_out")), Value::Null]);
+}
+
+#[test]
+fn stderr_null_clears_capture_and_drops_stderr() {
+    let helper = ns_string_literal(helper_path());
+    let src = format!(
+        r#"
+        make cmd get command({helper})
+        cmd.arg("echo-both")
+        cmd.arg("captured_out")
+        cmd.arg("dropped_err")
+        cmd.stdout_capture()
+        cmd.stderr_capture()
+        cmd.stderr_null()
+        make res get cmd.run()
+        shout(res.stdout())
+        shout(res.stderr())
+        "#
+    );
+
+    assert_process_output!(&src, vec![Value::Str(ArenaCow::borrowed("captured_out")), Value::Null]);
+}
+
+#[test]
+fn timeout_reports_runtime_error() {
+    let helper = ns_string_literal(helper_path());
+    let src = format!(
+        r#"
+        make cmd get command({helper})
+        cmd.arg("sleep-ms")
+        cmd.arg("50")
+        cmd.timeout_ms(1)
+        cmd.run()
+        "#
+    );
+
+    assert_process_error!(&src, RuntimeErrorKind::ProcessTimeout);
+}
+
+#[test]
+fn capture_overflow_reports_runtime_error() {
+    let helper = ns_string_literal(helper_path());
+    let src = format!(
+        r#"
+        make cmd get command({helper})
+        cmd.arg("echo-stdout")
+        cmd.arg("hello")
+        cmd.stdout_capture()
+        cmd.run()
+        "#
+    );
+    let mut policy = HostPolicy::native_default();
+    policy.process.max_capture_bytes_per_stream = 4;
+
+    assert_process_error!(&src, RuntimeErrorKind::ProcessOutputLimitExceeded("stdout"), policy: policy);
+}
+
+#[test]
+fn invalid_utf8_capture_reports_runtime_error() {
+    let helper = ns_string_literal(helper_path());
+    let src = format!(
+        r#"
+        make cmd get command({helper})
+        cmd.arg("emit-bytes")
+        cmd.arg("ff")
+        cmd.stdout_capture()
+        cmd.run()
+        "#
+    );
+
+    assert_process_error!(&src, RuntimeErrorKind::ProcessInvalidUtf8("stdout"));
+}
+
+#[test]
+fn denied_policy_reports_runtime_error() {
+    let helper = ns_string_literal(helper_path());
+    let src = format!(
+        r#"
+        make cmd get command({helper})
+        cmd.arg("echo-stdout")
+        cmd.arg("hello")
+        cmd.run()
+        "#
+    );
+    let mut policy = HostPolicy::native_default();
+    policy.allow_process = false;
+
+    assert_process_error!(&src, RuntimeErrorKind::ProcessDenied, policy: policy);
+}

--- a/tests/resolver.rs
+++ b/tests/resolver.rs
@@ -126,6 +126,27 @@ fn test_unused_variable_after_never_read_decl() {
 }
 
 #[test]
+fn test_process_builder_mutation_requires_lvalue_receiver() {
+    assert_resolve!(r#"command("echo").arg("hello")"#, SemanticError::TypeMismatch);
+}
+
+#[test]
+fn test_process_value_rejected_in_arithmetic() {
+    assert_resolve!(r#"shout(command("echo") add 1)"#, SemanticError::TypeMismatch);
+}
+
+#[test]
+fn test_process_timeout_requires_number() {
+    assert_resolve!(
+        r#"
+        make cmd get command("echo")
+        cmd.timeout_ms("fast")
+        "#,
+        SemanticError::TypeMismatch
+    );
+}
+
+#[test]
 fn test_unused_variable_not_emitted_when_local_is_read() {
     with_pipeline("make x get 1 shout(x)", |_, (root, parse_errors), resolver, _| {
         use naijascript::diagnostics::AsStr;

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -292,7 +292,9 @@ fn array_output() {
     let src = "make nums get [1, 2, 3] shout(nums)";
     with_pipeline("", |arena, (_, _), _, _| {
         let mut value = Vec::with_capacity_in(3, arena);
-        value.extend_from_slice(&[Value::Number(1.0), Value::Number(2.0), Value::Number(3.0)]);
+        value.push(Value::Number(1.0));
+        value.push(Value::Number(2.0));
+        value.push(Value::Number(3.0));
         assert_runtime!(src, output: vec![Value::Array(value)]);
     });
 }


### PR DESCRIPTION
## Summary

This PR adds first-class process execution to NaijaScript in a way that fits the current tree-walk interpreter and scripting model.

The new surface is built around `command(program)`, a mutable `process_command` builder, and an immutable `process_result`. Execution is direct and synchronous, with no shell involvement. The runtime now supports bounded child-process execution with host policy control, timeout enforcement, stdout/stderr capture modes, stdin modes, cwd and env overrides, and explicit wasm unsupported behavior.

## What changed

- Added process execution core types and host policy in `src/process.rs`
- Added `command(...)`, `process_command`, and `process_result` builtins
- Integrated resolver/type/effect support for process values and methods
- Added runtime support for:
  - builder mutation
  - `run()`
  - result accessors
  - process-specific runtime errors
- Added bounded native execution backends for Unix and Windows
- Added wasm unsupported process runner path
- Added deterministic process integration coverage:
  - direct execution
  - non-zero exit handling
  - PATH lookup
  - argument preservation
  - cwd override
  - env override
  - stdin text and null
  - stdout/stderr capture
  - stdout/stderr inherit and null
  - timeout
  - capture overflow
  - invalid UTF-8
  - denied host policy
- Added user-facing process execution docs and linked them into the book
- Moved the process test helper out of the product binary surface into `tests/fixtures/`

## Notes

- Non-zero exit status is ordinary result data, not an interpreter error
- Process execution remains synchronous
- Shell execution, pipelines, background jobs, and binary capture are still out of scope
- The runtime still defaults to target host policy through `Runtime::new(...)`, while embedders can inject stricter policy with `Runtime::new_with_host_policy(...)`

## Verification

```bash
cargo fmt --all --check
cargo clippy --all-targets --all-features -- -W clippy::pedantic
cargo test -q
cargo check -p wasm --target wasm32-unknown-unknown
